### PR TITLE
fix: validate team invites before decision

### DIFF
--- a/src/app/team/invite/[inviteId]/page.tsx
+++ b/src/app/team/invite/[inviteId]/page.tsx
@@ -1,22 +1,63 @@
 'use client';
 
-import { useState } from 'react';
-import { useParams, useRouter, notFound } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { useParams, notFound } from 'next/navigation';
 import Link from 'next/link';
-import { Users, CheckCircle, XCircle, LogIn, Loader2, AlertTriangle } from 'lucide-react';
+import { Users, CheckCircle, XCircle, LogIn, Loader2, AlertTriangle, CalendarClock, Mail, User } from 'lucide-react';
 import { useSession } from '@/lib/auth/AuthContext';
-import { acceptTeamInvite, rejectTeamInvite } from '@/lib/api/team';
+import { acceptTeamInvite, getTeamInvite, rejectTeamInvite } from '@/lib/api/team';
+import { ApiException } from '@/lib/api/client';
+import type { TeamInviteResponse } from '@/lib/api/types';
 import { toast } from '@/lib/toast';
+
+function formatDateTime(dateString: string) {
+  return new Date(dateString).toLocaleString('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function InviteSummary({ invite }: { invite: TeamInviteResponse }) {
+  return (
+    <div className="mt-6 rounded-xl border border-gray-200 bg-gray-50 p-4 text-left">
+      <div className="flex items-center gap-2 text-sm font-semibold text-gray-900">
+        <Users className="h-4 w-4 text-blue-600" />
+        <span>{invite.team.name}</span>
+      </div>
+      <div className="mt-3 space-y-2 text-sm text-gray-600">
+        <div className="flex items-center gap-2">
+          <User className="h-4 w-4 text-gray-400" />
+          <span>초대한 사람: {invite.inviter.name}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <Mail className="h-4 w-4 text-gray-400" />
+          <span>초대 대상: {invite.invitee.name}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <CalendarClock className="h-4 w-4 text-gray-400" />
+          <span>만료 시각: {formatDateTime(invite.expiresAt)}</span>
+        </div>
+        <p className="pt-1 text-xs text-gray-500">
+          현재 팀원 {invite.team.memberCount}명
+        </p>
+      </div>
+    </div>
+  );
+}
 
 export default function TeamInvitePage() {
   const params = useParams();
-  const router = useRouter();
   const inviteId = params.inviteId as string;
   const { data: session, status } = useSession();
 
   const [isAccepting, setIsAccepting] = useState(false);
   const [isRejecting, setIsRejecting] = useState(false);
   const [result, setResult] = useState<'accepted' | 'rejected' | 'invalid' | null>(null);
+  const [invite, setInvite] = useState<TeamInviteResponse | null>(null);
+  const [inviteStatus, setInviteStatus] = useState<'loading' | 'ready' | 'invalid' | 'error'>('loading');
 
   // 초대 ID가 없으면 404
   if (!inviteId) {
@@ -26,6 +67,45 @@ export default function TeamInvitePage() {
   const currentUrl = typeof window !== 'undefined'
     ? window.location.pathname
     : `/team/invite/${inviteId}`;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchInvite = async () => {
+      setInviteStatus('loading');
+
+      try {
+        const inviteData = await getTeamInvite(inviteId);
+
+        if (cancelled) return;
+
+        if (new Date(inviteData.expiresAt).getTime() < Date.now()) {
+          setInviteStatus('invalid');
+          return;
+        }
+
+        setInvite(inviteData);
+        setInviteStatus('ready');
+      } catch (error) {
+        if (cancelled) return;
+
+        console.error('초대 조회 실패:', error);
+
+        if (error instanceof ApiException && error.status === 404) {
+          setInviteStatus('invalid');
+          return;
+        }
+
+        setInviteStatus('error');
+      }
+    };
+
+    void fetchInvite();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [inviteId]);
 
   const handleAccept = async () => {
     if (!session?.accessToken) {
@@ -40,8 +120,11 @@ export default function TeamInvitePage() {
       toast.success('팀 초대를 수락했습니다.');
     } catch (error) {
       console.error('초대 수락 실패:', error);
-      // 에러 발생 시 유효하지 않은 초대로 처리
-      setResult('invalid');
+      if (error instanceof ApiException && error.status === 404) {
+        setResult('invalid');
+        return;
+      }
+      toast.error(error instanceof Error ? error.message : '초대 수락에 실패했습니다.');
     } finally {
       setIsAccepting(false);
     }
@@ -60,15 +143,18 @@ export default function TeamInvitePage() {
       toast.success('팀 초대를 거절했습니다.');
     } catch (error) {
       console.error('초대 거절 실패:', error);
-      // 에러 발생 시 유효하지 않은 초대로 처리
-      setResult('invalid');
+      if (error instanceof ApiException && error.status === 404) {
+        setResult('invalid');
+        return;
+      }
+      toast.error(error instanceof Error ? error.message : '초대 거절에 실패했습니다.');
     } finally {
       setIsRejecting(false);
     }
   };
 
   // 로딩 중
-  if (status === 'loading') {
+  if (status === 'loading' || inviteStatus === 'loading') {
     return (
       <div className="flex min-h-screen items-center justify-center bg-gray-50">
         <Loader2 className="h-8 w-8 animate-spin text-gray-400" />
@@ -76,8 +162,38 @@ export default function TeamInvitePage() {
     );
   }
 
+  if (inviteStatus === 'error') {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
+        <div className="w-full max-w-md text-center">
+          <div className="mx-auto flex h-20 w-20 items-center justify-center rounded-full bg-red-100">
+            <AlertTriangle className="h-10 w-10 text-red-600" />
+          </div>
+          <h1 className="mt-6 text-2xl font-bold text-gray-900">
+            초대 정보를 불러오지 못했습니다
+          </h1>
+          <p className="mt-2 text-gray-600">
+            잠시 후 다시 시도해주세요.
+          </p>
+          <div className="mt-8">
+            <Link
+              href="/"
+              className="inline-flex items-center justify-center rounded-xl border border-gray-200 bg-white px-6 py-3 text-sm font-medium text-gray-700 transition hover:bg-gray-50"
+            >
+              홈으로 이동
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!invite) {
+    return null;
+  }
+
   // 유효하지 않은 초대
-  if (result === 'invalid') {
+  if (result === 'invalid' || inviteStatus === 'invalid') {
     return (
       <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
         <div className="w-full max-w-md text-center">
@@ -115,15 +231,16 @@ export default function TeamInvitePage() {
             팀에 합류했습니다!
           </h1>
           <p className="mt-2 text-gray-600">
-            팀 페이지에서 팀원들과 함께 활동해보세요.
+            {invite.team.name} 팀에서 팀원들과 함께 활동해보세요.
           </p>
+          <InviteSummary invite={invite} />
           <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:justify-center">
             <Link
-              href="/team"
+              href={`/team/${invite.team.id}`}
               className="inline-flex items-center justify-center gap-2 rounded-xl bg-gray-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-gray-800"
             >
               <Users className="h-4 w-4" />
-              팀 페이지로 이동
+              팀 상세로 이동
             </Link>
             <Link
               href="/"
@@ -149,8 +266,9 @@ export default function TeamInvitePage() {
             초대를 거절했습니다
           </h1>
           <p className="mt-2 text-gray-600">
-            다른 팀의 초대를 기다려보세요.
+            {invite.team.name} 팀 초대를 거절했습니다.
           </p>
+          <InviteSummary invite={invite} />
           <div className="mt-8">
             <Link
               href="/"
@@ -179,6 +297,7 @@ export default function TeamInvitePage() {
             <p className="mt-3 text-center text-sm text-gray-600">
               로그인 후 팀 초대 수락 여부를 결정할 수 있습니다.
             </p>
+            <InviteSummary invite={invite} />
             <div className="mt-8">
               <Link
                 href={`/login?callbackUrl=${encodeURIComponent(currentUrl)}`}
@@ -212,8 +331,9 @@ export default function TeamInvitePage() {
             팀에 초대받으셨습니다
           </h1>
           <p className="mt-3 text-center text-sm text-gray-600">
-            초대를 수락하시겠습니까?
+            {invite.team.name} 팀 초대를 수락하시겠습니까?
           </p>
+          <InviteSummary invite={invite} />
 
           <div className="mt-8 space-y-3">
             <button

--- a/src/lib/api/team.ts
+++ b/src/lib/api/team.ts
@@ -4,6 +4,7 @@ import type {
   TeamUpdateRequest,
   TeamListResponse,
   TeamDetailResponse,
+  TeamInviteResponse,
 } from './types';
 
 /**
@@ -63,6 +64,15 @@ export async function updateTeam(
     method: 'PUT',
     body: data,
     accessToken,
+  });
+}
+
+/**
+ * 팀 초대 상세 조회
+ */
+export async function getTeamInvite(inviteId: string): Promise<TeamInviteResponse> {
+  return apiClient<TeamInviteResponse>(`/v1/teams/invites/${inviteId}`, {
+    cache: 'no-store',
   });
 }
 

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -439,6 +439,22 @@ export interface TeamMemberResponse {
   role: 'LEADER' | 'MEMBER';
 }
 
+export interface TeamBasicInfo {
+  id: number;
+  name: string;
+  imageUrl: string | null;
+  memberCount: number;
+}
+
+export interface TeamInviteResponse {
+  id: number;
+  team: TeamBasicInfo;
+  inviter: AuthorResponse;
+  invitee: AuthorResponse;
+  expiresAt: string;
+  createdAt: string;
+}
+
 export interface TeamDetailResponse {
   id: number;
   name: string;


### PR DESCRIPTION
## Summary
- fetch team invite details on page load and treat missing or expired invites as invalid
- show invite information before login and before accept/reject actions
- add the invite detail API and response types used by the invite page

## Verification
- ./node_modules/.bin/eslint 'src/app/team/invite/[inviteId]/page.tsx' src/lib/api/team.ts src/lib/api/types.ts
- ./node_modules/.bin/tsc --noEmit