### PR TITLE
fix: 관리자 사용자 수정 페이지 추가 및 챌린지 조건 예시 형식 정리

### DIFF
--- a/src/app/admin/challenges/create/page.tsx
+++ b/src/app/admin/challenges/create/page.tsx
@@ -216,6 +216,9 @@ export default function CreateChallengePage() {
       hasCompound = prevPython !== python;
     }
 
+    python = python.replace(/T\(Math\)\.min\(/g, 'min(');
+    python = python.replace(/T\(Math\)\.max\(/g, 'max(');
+
     // 불필요한 괄호 정리 (최외곽 괄호만)
     python = python.trim();
     if (python.startsWith('(') && python.endsWith(')')) {
@@ -238,7 +241,7 @@ export default function CreateChallengePage() {
     // 연산자 변환
     python = python.replace(/&&/g, 'and');
     python = python.replace(/\|\|/g, 'or');
-    python = python.replace(/!/g, 'not ');
+    python = python.replace(/!(?!=)/g, 'not ');
     python = python.replace(/\btrue\b/g, 'True');
     python = python.replace(/\bfalse\b/g, 'False');
 

--- a/src/app/admin/challenges/edit/[id]/page.tsx
+++ b/src/app/admin/challenges/edit/[id]/page.tsx
@@ -189,6 +189,9 @@ export default function EditChallengePage() {
       hasCompound = prevPython !== python;
     }
 
+    python = python.replace(/T\(Math\)\.min\(/g, 'min(');
+    python = python.replace(/T\(Math\)\.max\(/g, 'max(');
+
     // 불필요한 괄호 정리 (최외곽 괄호만)
     python = python.trim();
     if (python.startsWith('(') && python.endsWith(')')) {
@@ -211,7 +214,7 @@ export default function EditChallengePage() {
     // SpEL 연산자를 Python으로 변환
     python = python.replace(/&&/g, 'and');
     python = python.replace(/\|\|/g, 'or');
-    python = python.replace(/!/g, 'not ');
+    python = python.replace(/!(?!=)/g, 'not ');
     python = python.replace(/\btrue\b/g, 'True');
     python = python.replace(/\bfalse\b/g, 'False');
 

--- a/src/app/admin/users/list/[id]/page.tsx
+++ b/src/app/admin/users/list/[id]/page.tsx
@@ -1,0 +1,299 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Image from 'next/image';
+import { ArrowLeft, Loader2, Save, Shield, UserRound, Mail, IdCard } from 'lucide-react';
+import { useSession } from '@/lib/auth/AuthContext';
+import { getAdminUserById, updateAdminUser } from '@/lib/api/admin';
+import { ApiException } from '@/lib/api/client';
+import type { AdminUserResponse, AdminUserUpdateRequest } from '@/types/admin';
+import { toast } from '@/lib/toast';
+import { ensureEncodedUrl } from '@/lib/utils';
+
+function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleString('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export default function AdminUserEditPage() {
+  const router = useRouter();
+  const params = useParams();
+  const { data: session, status } = useSession();
+  const userId = Number(params.id);
+  const isValidUserId = Number.isInteger(userId) && userId > 0;
+
+  const [user, setUser] = useState<AdminUserResponse | null>(null);
+  const [formData, setFormData] = useState<AdminUserUpdateRequest | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const fetchUser = useCallback(async () => {
+    if (!session?.accessToken) return;
+    if (!isValidUserId) {
+      setLoadError('잘못된 사용자 경로입니다.');
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setLoadError(null);
+
+    try {
+      const data = await getAdminUserById(userId, { accessToken: session.accessToken });
+      setUser(data);
+      setFormData({
+        name: data.name,
+        kutId: data.kutId,
+        kutEmail: data.kutEmail,
+        introduction: data.introduction || '',
+        profileImageUrl: data.profileImageUrl || '',
+      });
+    } catch (error) {
+      console.error('Failed to fetch admin user:', error);
+
+      if (error instanceof ApiException && error.status === 404) {
+        setLoadError('사용자를 찾을 수 없습니다.');
+        return;
+      }
+
+      setLoadError('사용자 정보를 불러오지 못했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [isValidUserId, session?.accessToken, userId]);
+
+  useEffect(() => {
+    if (status === 'authenticated' && session?.accessToken) {
+      void fetchUser();
+      return;
+    }
+
+    if (status === 'unauthenticated') {
+      router.push('/login');
+    }
+  }, [status, session?.accessToken, fetchUser, router]);
+
+  const handleChange = <K extends keyof AdminUserUpdateRequest>(key: K, value: AdminUserUpdateRequest[K]) => {
+    setFormData((prev) => {
+      if (!prev) return prev;
+      return { ...prev, [key]: value };
+    });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!session?.accessToken || !formData || !user) return;
+
+    if (!formData.name.trim() || !formData.kutId.trim() || !formData.kutEmail.trim()) {
+      toast.error('이름, 학번/사번, 이메일은 필수입니다.');
+      return;
+    }
+
+    setIsSaving(true);
+
+    try {
+      await updateAdminUser(
+        user.id,
+        {
+          name: formData.name.trim(),
+          kutId: formData.kutId.trim(),
+          kutEmail: formData.kutEmail.trim(),
+          introduction: formData.introduction?.trim() || '',
+          profileImageUrl: formData.profileImageUrl?.trim() || '',
+        },
+        { accessToken: session.accessToken }
+      );
+
+      toast.success('사용자 정보가 수정되었습니다.');
+      await fetchUser();
+    } catch (error) {
+      console.error('Failed to update admin user:', error);
+      toast.error(error instanceof Error ? error.message : '사용자 정보 수정에 실패했습니다.');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="p-6 md:p-8">
+      <div className="mx-auto max-w-4xl">
+        <div className="mb-6">
+          <button
+            onClick={() => router.push('/admin/users/list')}
+            className="mb-4 inline-flex items-center gap-1.5 text-sm text-gray-500 transition-colors hover:text-gray-900"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            사용자 목록으로
+          </button>
+          <h1 className="text-xl font-bold text-gray-900">사용자 정보 수정</h1>
+          <p className="mt-0.5 text-sm text-gray-500">
+            관리자 권한으로 사용자 기본 정보를 수정합니다.
+          </p>
+        </div>
+
+        {isLoading ? (
+          <div className="flex items-center justify-center py-20">
+            <Loader2 className="h-8 w-8 animate-spin text-gray-400" />
+          </div>
+        ) : loadError || !user || !formData ? (
+          <div className="rounded-xl border border-gray-200 bg-white p-10 text-center">
+            <p className="text-sm text-gray-600">{loadError || '사용자 정보를 불러올 수 없습니다.'}</p>
+          </div>
+        ) : (
+          <div className="grid gap-6 lg:grid-cols-[320px_minmax(0,1fr)]">
+            <aside className="rounded-xl border border-gray-200 bg-white p-6">
+              <div className="flex flex-col items-center text-center">
+                {user.profileImageUrl ? (
+                  <Image
+                    src={ensureEncodedUrl(user.profileImageUrl)}
+                    alt={user.name}
+                    width={96}
+                    height={96}
+                    className="h-24 w-24 rounded-full object-cover"
+                  />
+                ) : (
+                  <div className="flex h-24 w-24 items-center justify-center rounded-full bg-gray-900 text-2xl font-semibold text-white">
+                    {user.name[0]}
+                  </div>
+                )}
+                <h2 className="mt-4 text-lg font-semibold text-gray-900">{user.name}</h2>
+                <div className="mt-2 flex flex-wrap justify-center gap-2">
+                  {user.roles.map((role) => (
+                    <span
+                      key={role}
+                      className="rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-600"
+                    >
+                      {role.replace('ROLE_', '')}
+                    </span>
+                  ))}
+                </div>
+                <div className="mt-4 rounded-full px-3 py-1 text-xs font-medium text-white">
+                  <span className={user.isDeleted ? 'rounded-full bg-gray-400 px-3 py-1' : 'rounded-full bg-emerald-500 px-3 py-1'}>
+                    {user.isDeleted ? '탈퇴' : '활성'}
+                  </span>
+                </div>
+              </div>
+
+              <div className="mt-6 space-y-3 border-t border-gray-100 pt-6 text-sm text-gray-600">
+                <div className="flex items-center gap-2">
+                  <UserRound className="h-4 w-4 text-gray-400" />
+                  <span>ID {user.id}</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Mail className="h-4 w-4 text-gray-400" />
+                  <span className="break-all">{user.kutEmail}</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <IdCard className="h-4 w-4 text-gray-400" />
+                  <span>{user.kutId}</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Shield className="h-4 w-4 text-gray-400" />
+                  <span>가입일 {formatDate(user.createdAt)}</span>
+                </div>
+              </div>
+            </aside>
+
+            <section className="rounded-xl border border-gray-200 bg-white p-6">
+              <form onSubmit={handleSubmit} className="space-y-5">
+                <div className="grid gap-5 sm:grid-cols-2">
+                  <div>
+                    <label htmlFor="name" className="mb-2 block text-sm font-medium text-gray-700">
+                      이름
+                    </label>
+                    <input
+                      id="name"
+                      type="text"
+                      value={formData.name}
+                      onChange={(e) => handleChange('name', e.target.value)}
+                      className="w-full rounded-lg border border-gray-200 px-4 py-2.5 text-sm transition-colors focus:border-gray-400 focus:outline-none"
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="kutId" className="mb-2 block text-sm font-medium text-gray-700">
+                      학번/사번
+                    </label>
+                    <input
+                      id="kutId"
+                      type="text"
+                      value={formData.kutId}
+                      onChange={(e) => handleChange('kutId', e.target.value)}
+                      className="w-full rounded-lg border border-gray-200 px-4 py-2.5 text-sm transition-colors focus:border-gray-400 focus:outline-none"
+                    />
+                  </div>
+                </div>
+
+                <div>
+                  <label htmlFor="kutEmail" className="mb-2 block text-sm font-medium text-gray-700">
+                    KUT 이메일
+                  </label>
+                  <input
+                    id="kutEmail"
+                    type="email"
+                    value={formData.kutEmail}
+                    onChange={(e) => handleChange('kutEmail', e.target.value)}
+                    className="w-full rounded-lg border border-gray-200 px-4 py-2.5 text-sm transition-colors focus:border-gray-400 focus:outline-none"
+                  />
+                </div>
+
+                <div>
+                  <label htmlFor="profileImageUrl" className="mb-2 block text-sm font-medium text-gray-700">
+                    프로필 이미지 URL
+                  </label>
+                  <input
+                    id="profileImageUrl"
+                    type="url"
+                    value={formData.profileImageUrl || ''}
+                    onChange={(e) => handleChange('profileImageUrl', e.target.value)}
+                    placeholder="https://..."
+                    className="w-full rounded-lg border border-gray-200 px-4 py-2.5 text-sm transition-colors focus:border-gray-400 focus:outline-none"
+                  />
+                </div>
+
+                <div>
+                  <label htmlFor="introduction" className="mb-2 block text-sm font-medium text-gray-700">
+                    자기소개
+                  </label>
+                  <textarea
+                    id="introduction"
+                    value={formData.introduction || ''}
+                    onChange={(e) => handleChange('introduction', e.target.value)}
+                    rows={6}
+                    className="w-full rounded-lg border border-gray-200 px-4 py-3 text-sm transition-colors focus:border-gray-400 focus:outline-none"
+                    placeholder="자기소개를 입력하세요"
+                  />
+                </div>
+
+                <div className="flex items-center justify-end gap-3 border-t border-gray-100 pt-5">
+                  <button
+                    type="button"
+                    onClick={() => router.push('/admin/users/list')}
+                    className="rounded-lg border border-gray-200 px-4 py-2.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+                  >
+                    취소
+                  </button>
+                  <button
+                    type="submit"
+                    disabled={isSaving}
+                    className="inline-flex items-center gap-2 rounded-lg bg-gray-900 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {isSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+                    저장
+                  </button>
+                </div>
+              </form>
+            </section>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/users/list/page.tsx
+++ b/src/app/admin/users/list/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useSession } from '@/lib/auth/AuthContext';
 import Image from 'next/image';
-import { Search, Users, X, Check, Loader2 } from 'lucide-react';
+import { Search, Users, X, Check, Loader2, SquarePen } from 'lucide-react';
 import { adminSearch, getAdminUsers, getRoles, updateUserRoles, deleteAdminUser } from '@/lib/api/admin';
 import type { AdminSearchUserSummary, AdminUserResponse, RoleResponse } from '@/types/admin';
 import { toast } from '@/lib/toast';
@@ -332,7 +332,7 @@ export default function AdminUsersPage() {
             <ul className="divide-y divide-gray-100">
               {filteredUsers.map((user) => (
                 <li key={user.id} className="flex items-center gap-4 px-5 py-4 transition-colors hover:bg-gray-50">
-                  <Link href={`/user/${user.id}`}>
+                  <Link href={`/admin/users/list/${user.id}`}>
                     {user.profileImageUrl ? (
                       <Image
                         src={ensureEncodedUrl(user.profileImageUrl)}
@@ -349,7 +349,7 @@ export default function AdminUsersPage() {
                   </Link>
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-2">
-                      <Link href={`/user/${user.id}`} className="truncate font-medium text-gray-900 hover:underline">{user.name}</Link>
+                      <Link href={`/admin/users/list/${user.id}`} className="truncate font-medium text-gray-900 hover:underline">{user.name}</Link>
                       {user.isDeleted ? (
                         <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500">탈퇴</span>
                       ) : (
@@ -375,6 +375,13 @@ export default function AdminUsersPage() {
                     </div>
                   </div>
                   <div className="flex shrink-0 items-center gap-2">
+                    <Link
+                      href={`/admin/users/list/${user.id}`}
+                      className="inline-flex items-center gap-1 rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-50"
+                    >
+                      <SquarePen className="h-3.5 w-3.5" />
+                      수정
+                    </Link>
                     <button
                       onClick={() => {
                         setSelectedUser(user);

--- a/src/common/components/SpelEditor/index.tsx
+++ b/src/common/components/SpelEditor/index.tsx
@@ -29,6 +29,8 @@ function pythonToSpel(python: string): string {
   // Python 불리언을 SpEL로 변환
   spel = spel.replace(/\bTrue\b/g, 'true');
   spel = spel.replace(/\bFalse\b/g, 'false');
+  spel = spel.replace(/\bmin\(/g, 'T(Math).min(');
+  spel = spel.replace(/\bmax\(/g, 'T(Math).max(');
 
   return spel;
 }
@@ -282,6 +284,8 @@ export default function SpelEditor({
           { label: 'and', kind: monaco.languages.CompletionItemKind.Keyword, insertText: 'and', detail: '논리 AND (&&)', range },
           { label: 'or', kind: monaco.languages.CompletionItemKind.Keyword, insertText: 'or', detail: '논리 OR (||)', range },
           { label: 'not', kind: monaco.languages.CompletionItemKind.Keyword, insertText: 'not ', detail: '논리 NOT (!)', range },
+          { label: 'min', kind: monaco.languages.CompletionItemKind.Function, insertText: 'min(${1:a}, ${2:b})', insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet, detail: '최솟값 함수', range },
+          { label: 'max', kind: monaco.languages.CompletionItemKind.Function, insertText: 'max(${1:a}, ${2:b})', insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet, detail: '최댓값 함수', range },
           { label: 'True', kind: monaco.languages.CompletionItemKind.Keyword, insertText: 'True', detail: '참', range },
           { label: 'False', kind: monaco.languages.CompletionItemKind.Keyword, insertText: 'False', detail: '거짓', range },
         ];

--- a/src/lib/api/admin.ts
+++ b/src/lib/api/admin.ts
@@ -1,4 +1,4 @@
-import { clientApiClient } from './client';
+import { ApiException, clientApiClient } from './client';
 import type {
   PermissionResponse,
   PermissionListResponse,
@@ -12,6 +12,8 @@ import type {
   RoleCreateRequest,
   RoleUpdateRequest,
   AdminUserListResponse,
+  AdminUserResponse,
+  AdminUserUpdateRequest,
   AdminChallengeResponse,
   AdminChallengeListResponse,
   AdminChallengeCreateRequest,
@@ -268,6 +270,8 @@ interface GetUsersParams {
   size?: number;
 }
 
+const ADMIN_USER_SCAN_PAGE_SIZE = 100;
+
 /**
  * 회원 목록 조회 (관리자용)
  */
@@ -293,7 +297,7 @@ export async function getAdminUsers(
  */
 export async function updateAdminUser(
   userId: number,
-  data: { name?: string; introduction?: string; profileImageUrl?: string },
+  data: AdminUserUpdateRequest,
   auth: AuthOptions
 ): Promise<void> {
   await clientApiClient<void>(`/v1/admin/users/${userId}`, {
@@ -301,6 +305,32 @@ export async function updateAdminUser(
     body: data,
     accessToken: auth.accessToken,
   });
+}
+
+/**
+ * 사용자 단건 조회 대체
+ * 관리 API 명세에 단건 GET이 없어 목록 API를 순회하여 사용자를 찾음
+ */
+export async function getAdminUserById(
+  userId: number,
+  auth: AuthOptions
+): Promise<AdminUserResponse> {
+  let page = 1;
+  let totalPages = 1;
+
+  while (page <= totalPages) {
+    const data = await getAdminUsers({ page, size: ADMIN_USER_SCAN_PAGE_SIZE }, auth);
+    const found = data.users.find((user) => user.id === userId);
+
+    if (found) {
+      return found;
+    }
+
+    totalPages = data.totalPages || 1;
+    page += 1;
+  }
+
+  throw new ApiException(404, '사용자를 찾을 수 없습니다.');
 }
 
 /**

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -96,7 +96,9 @@ export interface AdminUserListResponse {
 }
 
 export interface AdminUserUpdateRequest {
-  name?: string;
+  name: string;
+  kutEmail: string;
+  kutId: string;
   introduction?: string;
   profileImageUrl?: string;
 }


### PR DESCRIPTION
## 변경 내용
- 관리자 사용자 목록에서 전용 수정 페이지로 이동해 사용자 기본 정보를 수정할 수 있도록 추가했습니다.
- 관리자 사용자 수정 요청 타입을 API 명세에 맞게 `name`, `kutId`, `kutEmail`, `introduction`, `profileImageUrl` 기준으로 정리했습니다.
- 챌린지 생성/수정 화면에서 조건 예시를 클릭하면 Python 스타일 `min`, `max` 함수로 입력되고, SpEL 변환 결과만 별도로 표시되도록 수정했습니다.
- 잘못된 사용자 경로로 진입했을 때 로딩 상태에 머무르지 않고 오류 상태로 처리되도록 보완했습니다.

## 검증
- `./node_modules/.bin/eslint src/app/admin/challenges/create/page.tsx 'src/app/admin/challenges/edit/[id]/page.tsx' src/app/admin/users/list/page.tsx 'src/app/admin/users/list/[id]/page.tsx' src/common/components/SpelEditor/index.tsx src/lib/api/admin.ts src/types/admin.ts`
- `./node_modules/.bin/tsc --noEmit`