### PR TITLE
fix: 알림 타입 반영 및 회원가입 비밀번호 안내 문구 추가

### DIFF
--- a/src/app/notification/NotificationPageClient.tsx
+++ b/src/app/notification/NotificationPageClient.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo, useEffect, useCallback } from 'react';
 import Link from 'next/link';
 import type { AuthSession } from '@/lib/auth/types';
-import { Bell, Check, Trash2, Trophy, Award, AlertTriangle, Settings, Loader2 } from 'lucide-react';
+import { Bell, Check, Trash2, Trophy, Award, AlertTriangle, Settings, Loader2, UserPlus } from 'lucide-react';
 import {
   getNotifications,
   markNotificationAsRead,
@@ -17,7 +17,7 @@ import Pagination from '@/common/components/Pagination';
 
 const PAGE_SIZE = 10;
 
-type FilterType = '전체' | '신고' | '챌린지' | '포인트' | '시스템';
+type FilterType = '전체' | '신고' | '챌린지' | '포인트' | '팀' | '시스템';
 
 interface NotificationPageClientProps {
   session: AuthSession | null;
@@ -28,6 +28,7 @@ const FILTERS: { id: FilterType; label: string; types: NotificationType[] | null
   { id: '신고', label: '신고', types: ['ARTICLE_REPORTED', 'COMMENT_REPORTED'] },
   { id: '챌린지', label: '챌린지', types: ['CHALLENGE_ACHIEVED'] },
   { id: '포인트', label: '포인트', types: ['POINT_EARNED'] },
+  { id: '팀', label: '팀', types: ['TEAM_INVITED'] },
   { id: '시스템', label: '시스템', types: ['SYSTEM'] },
 ];
 
@@ -40,6 +41,8 @@ const getNotificationIcon = (type: NotificationType) => {
       return <Trophy className="h-4 w-4" />;
     case 'POINT_EARNED':
       return <Award className="h-4 w-4" />;
+    case 'TEAM_INVITED':
+      return <UserPlus className="h-4 w-4" />;
     case 'SYSTEM':
       return <Settings className="h-4 w-4" />;
     default:
@@ -56,6 +59,8 @@ const getNotificationColor = (type: NotificationType) => {
       return 'bg-amber-100 text-amber-600';
     case 'POINT_EARNED':
       return 'bg-green-100 text-green-600';
+    case 'TEAM_INVITED':
+      return 'bg-sky-100 text-sky-600';
     case 'SYSTEM':
       return 'bg-gray-100 text-gray-600';
     default:
@@ -76,6 +81,8 @@ const getNotificationLink = (notification: NotificationResponse): string => {
       return '/challenge';
     case 'POINT_EARNED':
       return '/user/points';
+    case 'TEAM_INVITED':
+      return `/team/invite/${referenceId}`;
     case 'SYSTEM':
     default:
       return '#';

--- a/src/app/signup/InfoStep.tsx
+++ b/src/app/signup/InfoStep.tsx
@@ -28,6 +28,8 @@ interface InfoStepProps {
 }
 
 const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/;
+const ALLOWED_SPECIAL_CHARACTERS = '@$!%*#?&';
+const INVALID_PASSWORD_CHARACTER_REGEX = /[^A-Za-z\d@$!%*#?&]/;
 
 function PasswordRequirement({ met, label }: { met: boolean; label: string }) {
   return (
@@ -70,6 +72,7 @@ export default function InfoStep({
   const hasNumber = /\d/.test(formData.password);
   const hasSpecial = /[@$!%*#?&]/.test(formData.password);
   const hasMinLength = formData.password.length >= 8;
+  const hasOnlyAllowedCharacters = !INVALID_PASSWORD_CHARACTER_REGEX.test(formData.password);
 
   const passwordsMatch = formData.password === formData.passwordConfirm && formData.passwordConfirm.length > 0;
   const isPasswordValid = PASSWORD_REGEX.test(formData.password);
@@ -214,7 +217,7 @@ export default function InfoStep({
           required
           value={formData.password}
           onChange={(e) => onFormChange('password', e.target.value)}
-          placeholder="비밀번호 (8자 이상, 영문/숫자/특수문자)"
+          placeholder={`비밀번호 (영문/숫자/허용 특수문자 ${ALLOWED_SPECIAL_CHARACTERS})`}
           className="w-full h-[54px] px-4 pr-12 bg-[#f2f4f6] rounded-2xl text-[15px] text-[#191f28] placeholder:text-[#8b95a1] border-0 focus:outline-none focus:ring-2 focus:ring-[#3182f6] transition-all"
         />
         <button
@@ -225,12 +228,24 @@ export default function InfoStep({
           {showPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
         </button>
       </div>
+      <p className="px-1 text-[12px] text-[#8b95a1]">
+        허용 특수문자: <span className="font-medium text-[#4e5968]">{ALLOWED_SPECIAL_CHARACTERS}</span>
+        {' '}| 그 외 특수문자는 사용할 수 없어요
+      </p>
       {formData.password && (
-        <div className="flex flex-wrap gap-x-4 gap-y-1 px-1">
+        <div className="space-y-2 px-1">
+          {!hasOnlyAllowedCharacters && (
+            <p className="text-[13px] text-[#e53935]">
+              허용되지 않은 특수문자가 포함되어 있어요. 사용 가능: {ALLOWED_SPECIAL_CHARACTERS}
+            </p>
+          )}
+          <div className="flex flex-wrap gap-x-4 gap-y-1">
           <PasswordRequirement met={hasMinLength} label="8자 이상" />
           <PasswordRequirement met={hasLetter} label="영문" />
           <PasswordRequirement met={hasNumber} label="숫자" />
-          <PasswordRequirement met={hasSpecial} label="특수문자" />
+          <PasswordRequirement met={hasSpecial} label={`특수문자 (${ALLOWED_SPECIAL_CHARACTERS})`} />
+          <PasswordRequirement met={hasOnlyAllowedCharacters} label="허용되지 않은 문자 없음" />
+          </div>
         </div>
       )}
 

--- a/src/common/components/Header/NotificationDropdown.tsx
+++ b/src/common/components/Header/NotificationDropdown.tsx
@@ -31,6 +31,8 @@ function getNotificationLink(notification: NotificationResponse): string {
       return '/challenge';
     case 'POINT_EARNED':
       return '/user/points';
+    case 'TEAM_INVITED':
+      return `/team/invite/${referenceId}`;
     default:
       return '/notification';
   }
@@ -154,7 +156,7 @@ export default function NotificationDropdown({ linkMode = false }: NotificationD
   // 드롭다운 모드: 드롭다운으로 알림 표시 (데스크톱용)
   return (
     <Menu as="div" className="relative">
-      {({ open }) => (
+      {() => (
         <>
           <Menu.Button
             onClick={handleOpen}

--- a/src/common/components/NotificationSSEProvider.tsx
+++ b/src/common/components/NotificationSSEProvider.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/navigation';
 import { toast } from '@/lib/toast';
 import { API_BASE_URL } from '@/lib/api/config';
 import type { NotificationResponse, NotificationType } from '@/lib/api/types';
-import { Bell, Trophy, Award, AlertTriangle, Settings } from 'lucide-react';
+import { Bell, Trophy, Award, AlertTriangle, Settings, UserPlus } from 'lucide-react';
 import { tokenManager } from '@/lib/auth/token-manager';
 import { signOutOnce } from '@/lib/auth/signout';
 import { fetchEventSource } from '@microsoft/fetch-event-source';
@@ -24,6 +24,8 @@ function getNotificationIcon(type: NotificationType) {
       return <Trophy className="h-4 w-4 text-amber-500" />;
     case 'POINT_EARNED':
       return <Award className="h-4 w-4 text-green-500" />;
+    case 'TEAM_INVITED':
+      return <UserPlus className="h-4 w-4 text-sky-500" />;
     case 'SYSTEM':
       return <Settings className="h-4 w-4 text-gray-500" />;
     default:
@@ -43,6 +45,8 @@ function getNotificationLink(notification: NotificationResponse): string | undef
       return '/challenge';
     case 'POINT_EARNED':
       return '/user/points';
+    case 'TEAM_INVITED':
+      return `/team/invite/${referenceId}`;
     default:
       return '/notification';
   }

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -670,6 +670,7 @@ export type NotificationType =
   | 'COMMENT_REPORTED'
   | 'CHALLENGE_ACHIEVED'
   | 'POINT_EARNED'
+  | 'TEAM_INVITED'
   | 'SYSTEM';
 
 export interface NotificationResponse {


### PR DESCRIPTION
## 변경 내용
- 최신 명세에 맞춰 알림 타입에 `TEAM_INVITED`를 반영했습니다.
- 팀 초대 알림 클릭 시 `referenceId`를 초대 ID로 사용해 초대 수락/거절 페이지로 이동하도록 연결했습니다.
- 회원가입 비밀번호 입력란에 허용 특수문자 집합(`@$!%*#?&`)을 직접 표시하고, 허용되지 않은 문자가 들어오면 즉시 안내되도록 수정했습니다.

## 검증
- `./node_modules/.bin/eslint src/app/notification/NotificationPageClient.tsx src/app/signup/InfoStep.tsx src/common/components/Header/NotificationDropdown.tsx src/common/components/NotificationSSEProvider.tsx src/lib/api/types.ts`
- `./node_modules/.bin/tsc --noEmit`