### PR TITLE
관리자 사용자·포인트 화면 정리 및 조건식 입력 개선

### DIFF
--- a/src/app/admin/points/[userId]/page.tsx
+++ b/src/app/admin/points/[userId]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import { useSession } from '@/lib/auth/AuthContext';
 import {
@@ -11,6 +11,8 @@ import {
   Coins,
   TrendingUp,
   TrendingDown,
+  CircleAlert,
+  RefreshCcw,
 } from 'lucide-react';
 import { getUserPointHistory, updateUserPoints } from '@/lib/api/admin';
 import type { PointHistoryResponse, PointTransaction } from '@/types/admin';
@@ -20,7 +22,7 @@ import Pagination from '@/common/components/Pagination';
 const PAGE_SIZE = 10;
 
 function formatDate(dateString: string): string {
-  return new Date(dateString).toLocaleDateString('ko-KR', {
+  return new Date(dateString).toLocaleString('ko-KR', {
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',
@@ -33,26 +35,52 @@ function formatNumber(num: number): string {
   return num.toLocaleString('ko-KR');
 }
 
+function TransactionTypeBadge({ amount }: { amount: number }) {
+  if (amount > 0) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-green-50 px-2.5 py-1 text-xs font-medium text-green-700">
+        <TrendingUp className="h-3.5 w-3.5" />
+        적립
+      </span>
+    );
+  }
+
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full bg-red-50 px-2.5 py-1 text-xs font-medium text-red-700">
+      <TrendingDown className="h-3.5 w-3.5" />
+      회수
+    </span>
+  );
+}
+
 export default function AdminPointDetailPage() {
   const router = useRouter();
   const params = useParams();
   const userId = Number(params.userId);
+  const isValidUserId = Number.isInteger(userId) && userId > 0;
   const { data: session, status } = useSession();
 
   const [pointHistory, setPointHistory] = useState<PointHistoryResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(0);
 
-  // 포인트 변경 폼 상태
   const [transactionType, setTransactionType] = useState<'add' | 'subtract'>('add');
   const [amount, setAmount] = useState('');
   const [reason, setReason] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const fetchPointHistory = useCallback(async () => {
-    if (!session?.accessToken || !userId) return;
+    if (!session?.accessToken) return;
+    if (!isValidUserId) {
+      setLoadError('잘못된 사용자 경로입니다.');
+      setIsLoading(false);
+      return;
+    }
 
     setIsLoading(true);
+    setLoadError(null);
+
     try {
       const data = await getUserPointHistory(
         userId,
@@ -62,15 +90,16 @@ export default function AdminPointDetailPage() {
       setPointHistory(data);
     } catch (err) {
       console.error('Failed to fetch point history:', err);
+      setLoadError('포인트 내역을 불러오는데 실패했습니다.');
       toast.error('포인트 내역을 불러오는데 실패했습니다.');
     } finally {
       setIsLoading(false);
     }
-  }, [session?.accessToken, userId, currentPage]);
+  }, [currentPage, isValidUserId, session?.accessToken, userId]);
 
   useEffect(() => {
     if (status === 'authenticated' && session?.accessToken) {
-      fetchPointHistory();
+      void fetchPointHistory();
       return;
     }
 
@@ -79,13 +108,21 @@ export default function AdminPointDetailPage() {
     }
   }, [status, session?.accessToken, fetchPointHistory, router]);
 
+  const previewAmount = Number.parseInt(amount, 10);
+  const isAmountValid = Number.isFinite(previewAmount) && previewAmount > 0;
+  const signedPreview = transactionType === 'add' ? previewAmount : -previewAmount;
+
+  const currentPageDelta = useMemo(() => {
+    if (!pointHistory?.transactions?.length) return 0;
+    return pointHistory.transactions.reduce((sum, transaction) => sum + transaction.amount, 0);
+  }, [pointHistory?.transactions]);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    if (!session?.accessToken) return;
+    if (!session?.accessToken || !isValidUserId) return;
 
-    const numAmount = parseInt(amount, 10);
-    if (isNaN(numAmount) || numAmount <= 0) {
+    if (!isAmountValid) {
       toast.error('올바른 포인트를 입력해주세요.');
       return;
     }
@@ -95,7 +132,12 @@ export default function AdminPointDetailPage() {
       return;
     }
 
-    const finalPoint = transactionType === 'add' ? numAmount : -numAmount;
+    if (transactionType === 'subtract' && previewAmount > currentBalance) {
+      toast.error('현재 보유 포인트보다 많은 포인트는 회수할 수 없습니다.');
+      return;
+    }
+
+    const finalPoint = transactionType === 'add' ? previewAmount : -previewAmount;
 
     setIsSubmitting(true);
     try {
@@ -106,13 +148,12 @@ export default function AdminPointDetailPage() {
       );
       toast.success(
         transactionType === 'add'
-          ? `${formatNumber(numAmount)} 포인트가 적립되었습니다.`
-          : `${formatNumber(numAmount)} 포인트가 회수되었습니다.`
+          ? `${formatNumber(previewAmount)} 포인트가 적립되었습니다.`
+          : `${formatNumber(previewAmount)} 포인트가 회수되었습니다.`
       );
       setAmount('');
       setReason('');
-      setCurrentPage(0);
-      fetchPointHistory();
+      await fetchPointHistory();
     } catch (err) {
       console.error('Failed to update points:', err);
       toast.error('포인트 변경에 실패했습니다.');
@@ -122,228 +163,294 @@ export default function AdminPointDetailPage() {
   };
 
   const totalPages = pointHistory?.totalPages || 1;
+  const currentBalance = pointHistory?.currentBalance || 0;
+  const previewBalance = isAmountValid ? currentBalance + signedPreview : currentBalance;
+  const exceedsCurrentBalance =
+    transactionType === 'subtract' && isAmountValid && previewAmount > currentBalance;
 
   return (
     <div className="p-6 md:p-8">
-      <div className="mx-auto max-w-4xl">
-        {/* 뒤로가기 & 헤더 */}
+      <div className="mx-auto max-w-7xl">
         <div className="mb-6">
           <button
-            onClick={() => router.back()}
+            onClick={() => router.push('/admin/points')}
             className="mb-4 inline-flex items-center gap-1.5 text-sm text-gray-500 transition-colors hover:text-gray-900"
           >
             <ArrowLeft className="h-4 w-4" />
-            목록으로
+            포인트 목록으로
           </button>
           <h1 className="text-xl font-bold text-gray-900">포인트 관리</h1>
-          {pointHistory && (
-            <p className="mt-0.5 text-sm text-gray-500">
-              {pointHistory.userName}님의 포인트를 관리합니다.
-            </p>
-          )}
+          <p className="mt-1 text-sm text-gray-500">
+            {pointHistory ? `${pointHistory.userName}님의 포인트를 관리합니다.` : '사용자 포인트 원장을 관리합니다.'}
+          </p>
         </div>
 
         {isLoading && !pointHistory ? (
-          <div className="flex items-center justify-center py-16">
-            <Loader2 className="h-8 w-8 animate-spin text-gray-400" />
+          <div className="rounded-xl border border-gray-200 bg-white py-16 text-center">
+            <Loader2 className="mx-auto h-6 w-6 animate-spin text-gray-400" />
+            <p className="mt-2 text-sm text-gray-500">불러오는 중...</p>
+          </div>
+        ) : loadError || !pointHistory ? (
+          <div className="rounded-xl border border-red-200 bg-red-50 px-6 py-14 text-center">
+            <CircleAlert className="mx-auto h-8 w-8 text-red-400" />
+            <p className="mt-3 text-sm text-gray-700">{loadError || '포인트 정보를 불러올 수 없습니다.'}</p>
+            <button
+              onClick={() => void fetchPointHistory()}
+              className="mt-4 rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-800"
+            >
+              다시 시도
+            </button>
           </div>
         ) : (
-          <div className="space-y-6">
-            {/* 현재 잔액 카드 */}
-            <div className="rounded-xl border border-gray-200 bg-white p-6">
-              <div className="flex items-center gap-3">
-                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-yellow-100">
-                  <Coins className="h-6 w-6 text-yellow-600" />
+          <>
+            <div className="mb-6 grid gap-6 xl:grid-cols-[360px_minmax(0,1fr)]">
+              <section className="rounded-xl border border-gray-200 bg-white">
+                <div className="border-b border-gray-200 px-5 py-4">
+                  <h2 className="font-semibold text-gray-900">포인트 조정</h2>
                 </div>
-                <div>
-                  <p className="text-sm text-gray-500">현재 잔액</p>
-                  <p className="text-2xl font-bold text-gray-900">
-                    {formatNumber(pointHistory?.currentBalance || 0)} P
-                  </p>
-                </div>
-              </div>
-            </div>
 
-            {/* 포인트 적립/회수 폼 */}
-            <div className="rounded-xl border border-gray-200 bg-white p-6">
-              <h2 className="mb-4 text-lg font-semibold text-gray-900">포인트 변경</h2>
-              <form onSubmit={handleSubmit} className="space-y-4">
-                {/* 적립/회수 선택 */}
-                <div>
-                  <label className="mb-2 block text-sm font-medium text-gray-700">
-                    유형 선택
-                  </label>
-                  <div className="flex gap-3">
+                <div className="space-y-4 px-5 py-5">
+                  <div className="grid grid-cols-2 gap-2">
                     <button
                       type="button"
                       onClick={() => setTransactionType('add')}
-                      className={`flex flex-1 items-center justify-center gap-2 rounded-lg border-2 py-3 text-sm font-medium transition-all ${
+                      className={`rounded-lg border px-4 py-2.5 text-sm font-medium transition-colors ${
                         transactionType === 'add'
                           ? 'border-green-500 bg-green-50 text-green-700'
-                          : 'border-gray-200 text-gray-600 hover:border-gray-300'
+                          : 'border-gray-200 text-gray-600 hover:bg-gray-50'
                       }`}
                     >
-                      <Plus className="h-4 w-4" />
-                      적립
+                      <span className="inline-flex items-center gap-1.5">
+                        <Plus className="h-4 w-4" />
+                        적립
+                      </span>
                     </button>
                     <button
                       type="button"
                       onClick={() => setTransactionType('subtract')}
-                      className={`flex flex-1 items-center justify-center gap-2 rounded-lg border-2 py-3 text-sm font-medium transition-all ${
+                      className={`rounded-lg border px-4 py-2.5 text-sm font-medium transition-colors ${
                         transactionType === 'subtract'
                           ? 'border-red-500 bg-red-50 text-red-700'
-                          : 'border-gray-200 text-gray-600 hover:border-gray-300'
+                          : 'border-gray-200 text-gray-600 hover:bg-gray-50'
                       }`}
                     >
-                      <Minus className="h-4 w-4" />
-                      회수
+                      <span className="inline-flex items-center gap-1.5">
+                        <Minus className="h-4 w-4" />
+                        회수
+                      </span>
                     </button>
                   </div>
-                </div>
 
-                {/* 금액 입력 */}
-                <div>
-                  <label
-                    htmlFor="amount"
-                    className="mb-2 block text-sm font-medium text-gray-700"
-                  >
-                    포인트
-                  </label>
-                  <input
-                    type="number"
-                    id="amount"
-                    value={amount}
-                    onChange={(e) => setAmount(e.target.value)}
-                    placeholder="변경할 포인트를 입력하세요"
-                    min="1"
-                    className="w-full rounded-lg border border-gray-200 px-4 py-2.5 text-sm transition-colors focus:border-gray-400 focus:outline-none"
-                  />
-                </div>
+                  <form onSubmit={handleSubmit} className="space-y-4">
+                    <div>
+                      <label htmlFor="amount" className="mb-2 block text-sm font-medium text-gray-700">
+                        포인트 수량
+                      </label>
+                      <input
+                        id="amount"
+                        type="number"
+                        value={amount}
+                        onChange={(e) => setAmount(e.target.value)}
+                        min="1"
+                        placeholder="포인트를 입력하세요"
+                        className="w-full rounded-lg border border-gray-200 px-4 py-2.5 text-sm transition-colors focus:border-gray-400 focus:outline-none"
+                      />
+                      {exceedsCurrentBalance && (
+                        <p className="mt-2 text-sm text-red-600">
+                          현재 잔액보다 많은 포인트는 회수할 수 없습니다.
+                        </p>
+                      )}
+                    </div>
 
-                {/* 사유 입력 */}
-                <div>
-                  <label
-                    htmlFor="reason"
-                    className="mb-2 block text-sm font-medium text-gray-700"
-                  >
-                    변경 사유
-                  </label>
-                  <input
-                    type="text"
-                    id="reason"
-                    value={reason}
-                    onChange={(e) => setReason(e.target.value)}
-                    placeholder="변경 사유를 입력하세요"
-                    className="w-full rounded-lg border border-gray-200 px-4 py-2.5 text-sm transition-colors focus:border-gray-400 focus:outline-none"
-                  />
-                </div>
+                    <div>
+                      <label htmlFor="reason" className="mb-2 block text-sm font-medium text-gray-700">
+                        변경 사유
+                      </label>
+                      <textarea
+                        id="reason"
+                        value={reason}
+                        onChange={(e) => setReason(e.target.value)}
+                        rows={4}
+                        placeholder="예: 챌린지 운영 보정, 잘못 적립된 포인트 회수"
+                        className="w-full resize-none rounded-lg border border-gray-200 px-4 py-2.5 text-sm transition-colors focus:border-gray-400 focus:outline-none"
+                      />
+                    </div>
 
-                {/* 제출 버튼 */}
-                <button
-                  type="submit"
-                  disabled={isSubmitting || !amount || !reason.trim()}
-                  className={`w-full rounded-lg py-2.5 text-sm font-medium text-white transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
-                    transactionType === 'add'
-                      ? 'bg-green-600 hover:bg-green-700'
-                      : 'bg-red-600 hover:bg-red-700'
-                  }`}
-                >
-                  {isSubmitting ? (
-                    <span className="inline-flex items-center gap-2">
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                      처리 중...
-                    </span>
-                  ) : transactionType === 'add' ? (
-                    '포인트 적립'
-                  ) : (
-                    '포인트 회수'
-                  )}
-                </button>
-              </form>
+                    <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm">
+                      <div className="flex items-center justify-between text-gray-600">
+                        <span>현재 잔액</span>
+                        <span className="font-medium text-gray-900">{formatNumber(currentBalance)} P</span>
+                      </div>
+                      <div className="mt-2 flex items-center justify-between text-gray-600">
+                        <span>변경 예정</span>
+                        <span className={transactionType === 'add' ? 'font-medium text-green-600' : 'font-medium text-red-600'}>
+                          {isAmountValid ? `${signedPreview > 0 ? '+' : ''}${formatNumber(signedPreview)} P` : '-'}
+                        </span>
+                      </div>
+                      <div className="mt-2 flex items-center justify-between border-t border-gray-200 pt-2 text-gray-700">
+                        <span>적용 후 잔액</span>
+                        <span className="font-semibold text-gray-900">{formatNumber(previewBalance)} P</span>
+                      </div>
+                    </div>
+
+                    <button
+                      type="submit"
+                      disabled={isSubmitting || !isAmountValid || !reason.trim() || exceedsCurrentBalance}
+                      className={`inline-flex w-full items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium text-white transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+                        transactionType === 'add'
+                          ? 'bg-green-600 hover:bg-green-700'
+                          : 'bg-red-600 hover:bg-red-700'
+                      }`}
+                    >
+                      {isSubmitting ? (
+                        <>
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                          처리 중...
+                        </>
+                      ) : (
+                        <>
+                          {transactionType === 'add' ? <Plus className="h-4 w-4" /> : <Minus className="h-4 w-4" />}
+                          {transactionType === 'add' ? '포인트 적립' : '포인트 회수'}
+                        </>
+                      )}
+                    </button>
+                  </form>
+                </div>
+              </section>
+
+              <div className="space-y-4">
+                <section className="rounded-xl border border-gray-200 bg-white">
+                  <div className="border-b border-gray-200 px-5 py-4">
+                    <h2 className="font-semibold text-gray-900">기본 정보</h2>
+                  </div>
+
+                  <div className="grid gap-4 px-5 py-5 sm:grid-cols-2">
+                    <div>
+                      <p className="text-xs font-medium uppercase tracking-wider text-gray-400">사용자 ID</p>
+                      <p className="mt-1 text-sm text-gray-900">{pointHistory.userId}</p>
+                    </div>
+                    <div>
+                      <p className="text-xs font-medium uppercase tracking-wider text-gray-400">사용자명</p>
+                      <p className="mt-1 text-sm text-gray-900">{pointHistory.userName}</p>
+                    </div>
+                    <div>
+                      <p className="text-xs font-medium uppercase tracking-wider text-gray-400">현재 잔액</p>
+                      <p className="mt-1 text-sm font-semibold text-gray-900">{formatNumber(currentBalance)} P</p>
+                    </div>
+                    <div>
+                      <p className="text-xs font-medium uppercase tracking-wider text-gray-400">총 이력 건수</p>
+                      <p className="mt-1 text-sm text-gray-900">{formatNumber(pointHistory.totalElements)}건</p>
+                    </div>
+                    <div>
+                      <p className="text-xs font-medium uppercase tracking-wider text-gray-400">현재 페이지 순증감</p>
+                      <p className={`mt-1 text-sm font-semibold ${currentPageDelta >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                        {currentPageDelta > 0 ? '+' : ''}
+                        {formatNumber(currentPageDelta)} P
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-xs font-medium uppercase tracking-wider text-gray-400">현재 페이지</p>
+                      <p className="mt-1 text-sm text-gray-900">
+                        {currentPage + 1} / {totalPages}
+                      </p>
+                    </div>
+                  </div>
+                </section>
+
+              </div>
             </div>
 
-            {/* 포인트 내역 */}
-            <div className="rounded-xl border border-gray-200 bg-white">
-              <div className="border-b border-gray-200 px-6 py-4">
-                <h2 className="text-lg font-semibold text-gray-900">포인트 내역</h2>
+            <section className="overflow-hidden rounded-xl border border-gray-200 bg-white">
+              <div className="flex flex-col gap-1 border-b border-gray-200 px-4 py-3 text-sm text-gray-500 sm:flex-row sm:items-center sm:justify-between">
+                <span>포인트 내역</span>
+                <div className="flex items-center gap-3">
+                  <span>총 {formatNumber(pointHistory.totalElements)}건</span>
+                  <button
+                    type="button"
+                    onClick={() => void fetchPointHistory()}
+                    disabled={isLoading}
+                    className="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    <RefreshCcw className={`h-3.5 w-3.5 ${isLoading ? 'animate-spin' : ''}`} />
+                    새로고침
+                  </button>
+                </div>
               </div>
 
-              <div className="overflow-x-auto">
-                <table className="w-full">
-                  <thead>
-                    <tr className="border-b border-gray-200 bg-gray-50">
-                      <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">
-                        일시
-                      </th>
-                      <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">
-                        유형
-                      </th>
-                      <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">
-                        사유
-                      </th>
-                      <th className="px-6 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-500">
-                        금액
-                      </th>
-                      <th className="px-6 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-500">
-                        잔액
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-gray-100">
-                    {!pointHistory?.transactions ||
-                    pointHistory.transactions.length === 0 ? (
-                      <tr>
-                        <td colSpan={5} className="px-6 py-12 text-center">
-                          <Coins className="mx-auto h-8 w-8 text-gray-300" />
-                          <p className="mt-2 text-sm text-gray-500">
-                            포인트 내역이 없습니다.
-                          </p>
-                        </td>
-                      </tr>
-                    ) : (
-                      pointHistory.transactions.map((tx: PointTransaction, index: number) => (
-                        <tr key={`${tx.id}-${index}`} className="hover:bg-gray-50">
-                          <td className="whitespace-nowrap px-6 py-3 text-sm text-gray-600">
-                            {formatDate(tx.createdAt)}
-                          </td>
-                          <td className="px-6 py-3">
-                            {tx.amount > 0 ? (
-                              <span className="inline-flex items-center gap-1 rounded-full bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700">
-                                <TrendingUp className="h-3 w-3" />
-                                적립
-                              </span>
-                            ) : (
-                              <span className="inline-flex items-center gap-1 rounded-full bg-red-50 px-2 py-0.5 text-xs font-medium text-red-700">
-                                <TrendingDown className="h-3 w-3" />
-                                회수
-                              </span>
-                            )}
-                          </td>
-                          <td className="px-6 py-3 text-sm text-gray-600">
-                            {tx.reason}
-                          </td>
-                          <td
-                            className={`whitespace-nowrap px-6 py-3 text-right text-sm font-medium ${
+              {!pointHistory.transactions.length ? (
+                <div className="py-16 text-center">
+                  <Coins className="mx-auto h-8 w-8 text-gray-300" />
+                  <p className="mt-2 text-sm text-gray-500">포인트 내역이 없습니다.</p>
+                </div>
+              ) : (
+                <>
+                  <div className="hidden md:block overflow-x-auto">
+                    <table className="min-w-full">
+                      <thead className="bg-gray-50">
+                        <tr className="text-left text-xs font-semibold uppercase tracking-wider text-gray-500">
+                          <th className="px-4 py-3">일시</th>
+                          <th className="px-4 py-3">유형</th>
+                          <th className="px-4 py-3">사유</th>
+                          <th className="px-4 py-3 text-right">금액</th>
+                          <th className="px-4 py-3 text-right">잔액</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-gray-100">
+                        {pointHistory.transactions.map((tx: PointTransaction, index: number) => (
+                          <tr key={`${tx.id}-${index}`} className="hover:bg-gray-50">
+                            <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-600">
+                              {formatDate(tx.createdAt)}
+                            </td>
+                            <td className="px-4 py-3">
+                              <TransactionTypeBadge amount={tx.amount} />
+                            </td>
+                            <td className="px-4 py-3 text-sm text-gray-600">{tx.reason}</td>
+                            <td className={`whitespace-nowrap px-4 py-3 text-right text-sm font-medium ${
                               tx.amount > 0 ? 'text-green-600' : 'text-red-600'
-                            }`}
-                          >
+                            }`}>
+                              {tx.amount > 0 ? '+' : ''}
+                              {formatNumber(tx.amount)} P
+                            </td>
+                            <td className="whitespace-nowrap px-4 py-3 text-right text-sm font-medium text-gray-900">
+                              {formatNumber(tx.balanceAfter)} P
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+
+                  <ul className="divide-y divide-gray-100 md:hidden">
+                    {pointHistory.transactions.map((tx: PointTransaction, index: number) => (
+                      <li key={`${tx.id}-${index}`} className="space-y-3 px-4 py-4">
+                        <div className="flex items-start justify-between gap-3">
+                          <div>
+                            <TransactionTypeBadge amount={tx.amount} />
+                            <p className="mt-2 text-sm text-gray-900">{tx.reason}</p>
+                          </div>
+                          <div className={`text-sm font-medium ${tx.amount > 0 ? 'text-green-600' : 'text-red-600'}`}>
                             {tx.amount > 0 ? '+' : ''}
                             {formatNumber(tx.amount)} P
-                          </td>
-                          <td className="whitespace-nowrap px-6 py-3 text-right text-sm text-gray-900">
-                            {formatNumber(tx.balanceAfter)} P
-                          </td>
-                        </tr>
-                      ))
-                    )}
-                  </tbody>
-                </table>
-              </div>
+                          </div>
+                        </div>
+                        <div className="grid grid-cols-2 gap-3 text-xs text-gray-500">
+                          <div>
+                            <p className="mb-1 text-gray-400">일시</p>
+                            <p>{formatDate(tx.createdAt)}</p>
+                          </div>
+                          <div>
+                            <p className="mb-1 text-gray-400">잔액</p>
+                            <p className="font-medium text-gray-900">{formatNumber(tx.balanceAfter)} P</p>
+                          </div>
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                </>
+              )}
+            </section>
 
-            </div>
-
-            {/* 페이지네이션 */}
-            {pointHistory?.transactions && pointHistory.transactions.length > 0 && (
+            {pointHistory.transactions.length > 0 && (
               <div className="mt-4">
                 <Pagination
                   currentPage={currentPage + 1}
@@ -352,7 +459,7 @@ export default function AdminPointDetailPage() {
                 />
               </div>
             )}
-          </div>
+          </>
         )}
       </div>
     </div>

--- a/src/app/admin/points/page.tsx
+++ b/src/app/admin/points/page.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSession } from '@/lib/auth/AuthContext';
 import Image from 'next/image';
-import { Search, Users, Loader2, Coins } from 'lucide-react';
-import { getAdminUsers } from '@/lib/api/admin';
-import type { AdminUserResponse } from '@/types/admin';
+import { Search, Users, Loader2, Coins, RefreshCcw, X } from 'lucide-react';
+import { adminSearch, getAdminUsers } from '@/lib/api/admin';
+import type { AdminSearchUserSummary, AdminUserResponse } from '@/types/admin';
 import { toast } from '@/lib/toast';
 import Pagination from '@/common/components/Pagination';
 import { ensureEncodedUrl } from '@/lib/utils';
@@ -22,94 +22,302 @@ function formatDate(dateString: string | null): string {
   });
 }
 
+function UserAvatar({
+  name,
+  profileImageUrl,
+}: {
+  name: string;
+  profileImageUrl: string | null;
+}) {
+  if (profileImageUrl) {
+    return (
+      <Image
+        src={ensureEncodedUrl(profileImageUrl)}
+        alt={name}
+        width={40}
+        height={40}
+        className="h-10 w-10 rounded-full object-cover"
+      />
+    );
+  }
+
+  return (
+    <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-900 text-sm font-semibold text-white">
+      {name[0]}
+    </div>
+  );
+}
+
+function UserStatusBadge({ isDeleted }: { isDeleted: boolean }) {
+  return isDeleted ? (
+    <span className="inline-flex rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-600">
+      탈퇴
+    </span>
+  ) : (
+    <span className="inline-flex rounded-full bg-green-50 px-2.5 py-1 text-xs font-medium text-green-700">
+      활성
+    </span>
+  );
+}
+
 export default function AdminPointsPage() {
   const router = useRouter();
   const { data: session, status } = useSession();
   const [users, setUsers] = useState<AdminUserResponse[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
+  const [excludeDeleted, setExcludeDeleted] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
   const [totalItems, setTotalItems] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
+  const requestIdRef = useRef(0);
+  const userCacheRef = useRef(new Map<number, AdminUserResponse>());
+  const loadedPagesRef = useRef(new Set<number>());
+  const knownTotalPagesRef = useRef<number | null>(null);
+  const isSearchMode = searchQuery.trim().length > 0;
 
-  const fetchUsers = useCallback(async () => {
+  const resetUserCache = useCallback(() => {
+    userCacheRef.current.clear();
+    loadedPagesRef.current.clear();
+    knownTotalPagesRef.current = null;
+  }, []);
+
+  const cacheUserPage = useCallback((page: number, data: { users?: AdminUserResponse[]; totalPages?: number }) => {
+    loadedPagesRef.current.add(page);
+    data.users?.forEach((user) => {
+      userCacheRef.current.set(user.id, user);
+    });
+    if (data.totalPages !== undefined) {
+      knownTotalPagesRef.current = data.totalPages;
+    }
+  }, []);
+
+  const fetchUserPage = useCallback(async (page: number) => {
+    if (!session?.accessToken) {
+      return { users: [], totalPages: 1, totalElements: 0 };
+    }
+
+    const usersData = await getAdminUsers(
+      { page, size: PAGE_SIZE },
+      { accessToken: session.accessToken }
+    );
+
+    cacheUserPage(page, usersData);
+    return usersData;
+  }, [cacheUserPage, session?.accessToken]);
+
+  const fetchUsers = useCallback(async (requestId: number) => {
     if (!session?.accessToken) return;
 
     setIsLoading(true);
     try {
-      const usersData = await getAdminUsers(
-        { page: currentPage, size: PAGE_SIZE },
-        { accessToken: session.accessToken }
-      ).catch(() => ({ users: [], totalPages: 1, totalElements: 0 }));
+      const usersData = await fetchUserPage(currentPage);
+
+      if (requestId !== requestIdRef.current) return;
 
       setUsers(usersData.users || []);
       setTotalPages(usersData.totalPages || 1);
       setTotalItems(usersData.totalElements || 0);
     } catch (err) {
+      if (requestId !== requestIdRef.current) return;
+
       console.error('Failed to fetch users:', err);
-      toast.error('회원 목록을 불러오는데 실패했습니다.');
+      toast.error('포인트 관리 대상을 불러오는데 실패했습니다.');
       setUsers([]);
+      setTotalPages(1);
+      setTotalItems(0);
     } finally {
-      setIsLoading(false);
+      if (requestId === requestIdRef.current) {
+        setIsLoading(false);
+      }
     }
-  }, [session?.accessToken, currentPage]);
+  }, [currentPage, fetchUserPage, session?.accessToken]);
+
+  const hydrateSearchUsers = useCallback(async (searchUsers: AdminSearchUserSummary[]) => {
+    const searchIds = searchUsers.map((user) => user.id);
+    let missingIds = searchIds.filter((id) => !userCacheRef.current.has(id));
+    let page = 1;
+
+    while (missingIds.length > 0) {
+      const knownTotalPages = knownTotalPagesRef.current;
+      if (knownTotalPages !== null && page > knownTotalPages) break;
+
+      if (loadedPagesRef.current.has(page)) {
+        page += 1;
+        continue;
+      }
+
+      await fetchUserPage(page);
+      missingIds = searchIds.filter((id) => !userCacheRef.current.has(id));
+      page += 1;
+    }
+
+    return searchUsers
+      .map((user) => userCacheRef.current.get(user.id))
+      .filter((user): user is AdminUserResponse => Boolean(user));
+  }, [fetchUserPage]);
+
+  const searchUsers = useCallback(async (keyword: string, requestId: number) => {
+    if (!session?.accessToken) return;
+
+    setIsLoading(true);
+    try {
+      const searchData = await adminSearch(keyword, 'USER', { accessToken: session.accessToken });
+
+      if (requestId !== requestIdRef.current) return;
+
+      const hydratedUsers = await hydrateSearchUsers(searchData.users || []);
+
+      if (requestId !== requestIdRef.current) return;
+
+      setUsers(hydratedUsers);
+      setTotalPages(1);
+      setTotalItems(hydratedUsers.length);
+    } catch (err) {
+      if (requestId !== requestIdRef.current) return;
+
+      console.error('Failed to search users:', err);
+      toast.error('포인트 관리 사용자 검색에 실패했습니다.');
+      setUsers([]);
+      setTotalPages(1);
+      setTotalItems(0);
+    } finally {
+      if (requestId === requestIdRef.current) {
+        setIsLoading(false);
+      }
+    }
+  }, [hydrateSearchUsers, session?.accessToken]);
 
   useEffect(() => {
     if (status === 'authenticated' && session?.accessToken) {
-      fetchUsers();
       return;
     }
 
     if (status === 'unauthenticated') {
       router.push('/login');
     }
-  }, [status, session?.accessToken, fetchUsers, router]);
+  }, [status, session?.accessToken, router]);
+
+  useEffect(() => {
+    resetUserCache();
+  }, [resetUserCache, session?.accessToken]);
+
+  useEffect(() => {
+    if (status !== 'authenticated' || !session?.accessToken) return;
+
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    const keyword = searchQuery.trim();
+
+    if (!keyword) {
+      void fetchUsers(requestId);
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      void searchUsers(keyword, requestId);
+    }, 300);
+
+    return () => window.clearTimeout(timer);
+  }, [status, session?.accessToken, searchQuery, currentPage, fetchUsers, searchUsers]);
 
   const filteredUsers = users.filter((user) => {
-    if (!searchQuery.trim()) return true;
-    const query = searchQuery.toLowerCase();
-    return (
-      user.name?.toLowerCase().includes(query) ||
-      user.kutEmail?.toLowerCase().includes(query) ||
-      user.kutId?.toLowerCase().includes(query)
-    );
+    if (excludeDeleted && user.isDeleted) return false;
+    return true;
   });
+
+  const trimmedSearchQuery = searchQuery.trim();
+  const visibleCount = filteredUsers.length;
+  const activeVisibleCount = filteredUsers.filter((user) => !user.isDeleted).length;
+
+  const handleSearchChange = (value: string) => {
+    setSearchQuery(value);
+    if (currentPage !== 1) {
+      setCurrentPage(1);
+    }
+  };
+
+  const handleClearSearch = () => {
+    setSearchQuery('');
+    setCurrentPage(1);
+  };
+
+  const handleRefresh = async () => {
+    if (!session?.accessToken) return;
+
+    resetUserCache();
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+
+    await (trimmedSearchQuery ? searchUsers(trimmedSearchQuery, requestId) : fetchUsers(requestId));
+  };
 
   const handleUserClick = (userId: number) => {
     router.push(`/admin/points/${userId}`);
   };
 
-  const activeCount = users.filter((u) => !u.isDeleted).length;
-
   return (
     <div className="p-6 md:p-8">
-      <div className="mx-auto max-w-4xl">
-        {/* 헤더 */}
-        <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="mx-auto max-w-7xl">
+        <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
           <div>
             <h1 className="text-xl font-bold text-gray-900">포인트 관리</h1>
-            <p className="mt-0.5 text-sm text-gray-500">
-              전체 {totalItems.toLocaleString()}명 · 활성 {activeCount}명
+            <p className="mt-1 text-sm text-gray-500">
+              {isSearchMode
+                ? `검색 결과 ${totalItems.toLocaleString()}명`
+                : `전체 ${totalItems.toLocaleString()}명 · 현재 표시 ${visibleCount.toLocaleString()}명 · 활성 ${activeVisibleCount.toLocaleString()}명`}
             </p>
           </div>
 
-          {/* 검색 */}
-          <div className="w-full sm:w-72">
-            <div className="relative">
-              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
-              <input
-                type="text"
-                placeholder="이름, 이메일, 학번 검색"
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                className="w-full rounded-lg border border-gray-200 bg-white py-2 pl-9 pr-3 text-sm transition-colors focus:border-gray-400 focus:outline-none"
-              />
+          <div className="flex w-full flex-col gap-3 lg:w-auto lg:min-w-[440px]">
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <div className="relative flex-1">
+                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+                <input
+                  type="text"
+                  placeholder="이름, 이메일, 학번 검색"
+                  value={searchQuery}
+                  onChange={(e) => handleSearchChange(e.target.value)}
+                  className="w-full rounded-lg border border-gray-200 bg-white py-2.5 pl-9 pr-9 text-sm transition-colors focus:border-gray-400 focus:outline-none"
+                />
+                {trimmedSearchQuery && (
+                  <button
+                    type="button"
+                    onClick={handleClearSearch}
+                    className="absolute right-2 top-1/2 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700"
+                    aria-label="검색어 지우기"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={handleRefresh}
+                className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+              >
+                <RefreshCcw className="h-4 w-4" />
+                새로고침
+              </button>
             </div>
+            <label className="inline-flex cursor-pointer items-center gap-2 text-sm text-gray-600">
+              <input
+                type="checkbox"
+                checked={excludeDeleted}
+                onChange={(e) => setExcludeDeleted(e.target.checked)}
+                className="h-4 w-4 rounded border-gray-300 text-gray-900 focus:ring-gray-500"
+              />
+              탈퇴 회원 제외
+            </label>
           </div>
         </div>
 
-        {/* 회원 목록 */}
         <div className="overflow-hidden rounded-xl border border-gray-200 bg-white">
+          <div className="flex flex-col gap-1 border-b border-gray-200 px-4 py-3 text-sm text-gray-500 sm:flex-row sm:items-center sm:justify-between">
+            <span>{trimmedSearchQuery ? `검색어: ${trimmedSearchQuery}` : '포인트 관리 대상 목록'}</span>
+            <span>{excludeDeleted ? '탈퇴 회원 제외 적용됨' : '전체 사용자 표시 중'}</span>
+          </div>
+
           {isLoading ? (
             <div className="py-16 text-center">
               <Loader2 className="mx-auto h-6 w-6 animate-spin text-gray-400" />
@@ -119,64 +327,110 @@ export default function AdminPointsPage() {
             <div className="py-16 text-center">
               <Users className="mx-auto h-8 w-8 text-gray-300" />
               <p className="mt-2 text-sm text-gray-500">
-                {searchQuery ? '검색 결과가 없습니다' : '회원이 없습니다'}
+                {trimmedSearchQuery ? '검색 결과가 없습니다' : '회원이 없습니다'}
               </p>
             </div>
           ) : (
-            <ul className="divide-y divide-gray-100">
-              {filteredUsers.map((user) => (
-                <li
-                  key={user.id}
-                  className="flex cursor-pointer items-center gap-4 px-5 py-4 transition-colors hover:bg-gray-50"
-                  onClick={() => handleUserClick(user.id)}
-                >
-                  {user.profileImageUrl ? (
-                    <Image
-                      src={ensureEncodedUrl(user.profileImageUrl)}
-                      alt={user.name}
-                      width={36}
-                      height={36}
-                      className="h-9 w-9 shrink-0 rounded-full object-cover"
-                    />
-                  ) : (
-                    <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-gray-900 text-sm font-medium text-white">
-                      {user.name[0]}
-                    </div>
-                  )}
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
-                      <span className="truncate font-medium text-gray-900">{user.name}</span>
-                      {user.isDeleted ? (
-                        <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500">탈퇴</span>
-                      ) : (
-                        <span className="shrink-0 rounded-full bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700">활성</span>
-                      )}
-                    </div>
-                    <div className="mt-1 flex items-center gap-2 text-xs text-gray-500">
-                      <span>{user.kutId}</span>
-                      <span>{user.kutEmail}</span>
-                      <span>{formatDate(user.createdAt)}</span>
-                    </div>
-                  </div>
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleUserClick(user.id);
-                    }}
-                    className="inline-flex shrink-0 items-center gap-1.5 rounded-lg bg-gray-900 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-gray-800"
-                  >
-                    <Coins className="h-3.5 w-3.5" />
-                    포인트 관리
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
+            <>
+              <div className="hidden md:block overflow-x-auto">
+                <table className="min-w-full">
+                  <thead className="bg-gray-50">
+                    <tr className="text-left text-xs font-semibold uppercase tracking-wider text-gray-500">
+                      <th className="px-4 py-3">사용자</th>
+                      <th className="px-4 py-3">학번/사번</th>
+                      <th className="px-4 py-3">이메일</th>
+                      <th className="px-4 py-3">가입일</th>
+                      <th className="px-4 py-3">상태</th>
+                      <th className="px-4 py-3 text-right">작업</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100">
+                    {filteredUsers.map((user) => (
+                      <tr key={user.id} className="hover:bg-gray-50">
+                        <td className="px-4 py-3">
+                          <div className="flex items-center gap-3">
+                            <button
+                              type="button"
+                              onClick={() => handleUserClick(user.id)}
+                              className="shrink-0"
+                            >
+                              <UserAvatar name={user.name} profileImageUrl={user.profileImageUrl} />
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => handleUserClick(user.id)}
+                              className="truncate text-left font-medium text-gray-900 hover:underline"
+                            >
+                              {user.name}
+                            </button>
+                          </div>
+                        </td>
+                        <td className="px-4 py-3 text-sm text-gray-600">{user.kutId}</td>
+                        <td className="px-4 py-3 text-sm text-gray-600">{user.kutEmail}</td>
+                        <td className="px-4 py-3 text-sm text-gray-600">{formatDate(user.createdAt)}</td>
+                        <td className="px-4 py-3">
+                          <UserStatusBadge isDeleted={user.isDeleted} />
+                        </td>
+                        <td className="px-4 py-3">
+                          <div className="flex justify-end">
+                            <button
+                              type="button"
+                              onClick={() => handleUserClick(user.id)}
+                              className="inline-flex items-center gap-1.5 rounded-lg bg-gray-900 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-gray-800"
+                            >
+                              <Coins className="h-3.5 w-3.5" />
+                              포인트 관리
+                            </button>
+                          </div>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
 
+              <ul className="divide-y divide-gray-100 md:hidden">
+                {filteredUsers.map((user) => (
+                  <li key={user.id} className="space-y-3 px-4 py-4">
+                    <div className="flex items-start gap-3">
+                      <button type="button" onClick={() => handleUserClick(user.id)} className="shrink-0">
+                        <UserAvatar name={user.name} profileImageUrl={user.profileImageUrl} />
+                      </button>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2">
+                          <button
+                            type="button"
+                            onClick={() => handleUserClick(user.id)}
+                            className="truncate text-left font-medium text-gray-900 hover:underline"
+                          >
+                            {user.name}
+                          </button>
+                          <UserStatusBadge isDeleted={user.isDeleted} />
+                        </div>
+                        <div className="mt-1 space-y-1 text-xs text-gray-500">
+                          <p>{user.kutId}</p>
+                          <p className="truncate">{user.kutEmail}</p>
+                          <p>{formatDate(user.createdAt)}</p>
+                        </div>
+                      </div>
+                    </div>
+
+                    <button
+                      type="button"
+                      onClick={() => handleUserClick(user.id)}
+                      className="inline-flex w-full items-center justify-center gap-1.5 rounded-lg bg-gray-900 px-3 py-2 text-xs font-medium text-white transition-colors hover:bg-gray-800"
+                    >
+                      <Coins className="h-3.5 w-3.5" />
+                      포인트 관리
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
         </div>
 
-        {/* 페이지네이션 */}
-        {filteredUsers.length > 0 && (
+        {!isSearchMode && filteredUsers.length > 0 && (
           <div className="mt-4">
             <Pagination
               currentPage={currentPage}

--- a/src/app/admin/users/list/[id]/page.tsx
+++ b/src/app/admin/users/list/[id]/page.tsx
@@ -93,7 +93,7 @@ export default function AdminUserEditPage() {
     if (!session?.accessToken || !formData || !user) return;
 
     if (!formData.name.trim() || !formData.kutId.trim() || !formData.kutEmail.trim()) {
-      toast.error('이름, 학번/사번, 이메일은 필수입니다.');
+      toast.error('이름, 학번/사번, 아우누리 이메일은 필수입니다.');
       return;
     }
 
@@ -233,7 +233,7 @@ export default function AdminUserEditPage() {
 
                 <div>
                   <label htmlFor="kutEmail" className="mb-2 block text-sm font-medium text-gray-700">
-                    KUT 이메일
+                    아우누리 이메일
                   </label>
                   <input
                     id="kutEmail"

--- a/src/app/admin/users/list/page.tsx
+++ b/src/app/admin/users/list/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useSession } from '@/lib/auth/AuthContext';
 import Image from 'next/image';
-import { Search, Users, X, Check, Loader2, SquarePen } from 'lucide-react';
+import { Search, Users, X, Check, Loader2, SquarePen, RefreshCcw } from 'lucide-react';
 import { adminSearch, getAdminUsers, getRoles, updateUserRoles, deleteAdminUser } from '@/lib/api/admin';
 import type { AdminSearchUserSummary, AdminUserResponse, RoleResponse } from '@/types/admin';
 import { toast } from '@/lib/toast';
@@ -21,6 +21,48 @@ function formatDate(dateString: string | null): string {
     month: '2-digit',
     day: '2-digit',
   });
+}
+
+function getRoleLabel(role: string): string {
+  return role.replace('ROLE_', '');
+}
+
+function UserAvatar({
+  name,
+  profileImageUrl,
+}: {
+  name: string;
+  profileImageUrl: string | null;
+}) {
+  if (profileImageUrl) {
+    return (
+      <Image
+        src={ensureEncodedUrl(profileImageUrl)}
+        alt={name}
+        width={40}
+        height={40}
+        className="h-10 w-10 rounded-full object-cover"
+      />
+    );
+  }
+
+  return (
+    <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-900 text-sm font-semibold text-white">
+      {name[0]}
+    </div>
+  );
+}
+
+function UserStatusBadge({ isDeleted }: { isDeleted: boolean }) {
+  return isDeleted ? (
+    <span className="inline-flex rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-600">
+      탈퇴
+    </span>
+  ) : (
+    <span className="inline-flex rounded-full bg-green-50 px-2.5 py-1 text-xs font-medium text-green-700">
+      활성
+    </span>
+  );
 }
 
 export default function AdminUsersPage() {
@@ -111,11 +153,10 @@ export default function AdminUsersPage() {
         setIsLoading(false);
       }
     }
-  }, [session?.accessToken, currentPage, fetchUserPage]);
+  }, [currentPage, fetchUserPage, session?.accessToken]);
 
   const hydrateSearchUsers = useCallback(async (searchUsers: AdminSearchUserSummary[]) => {
     const searchIds = searchUsers.map((user) => user.id);
-
     let missingIds = searchIds.filter((id) => !userCacheRef.current.has(id));
     let page = 1;
 
@@ -242,8 +283,7 @@ export default function AdminUsersPage() {
       setSelectedUser(null);
     } catch (err) {
       console.error('Delete user failed:', err);
-      const errorMessage =
-        err instanceof Error ? err.message : '회원 탈퇴 처리에 실패했습니다.';
+      const errorMessage = err instanceof Error ? err.message : '회원 탈퇴 처리에 실패했습니다.';
       toast.error(errorMessage);
     } finally {
       setIsDeleting(false);
@@ -274,25 +314,85 @@ export default function AdminUsersPage() {
     }
   };
 
-  const activeCount = users.filter((user) => !user.isDeleted).length;
+  const trimmedSearchQuery = searchQuery.trim();
+  const visibleCount = filteredUsers.length;
+  const activeVisibleCount = filteredUsers.filter((user) => !user.isDeleted).length;
+
+  const handleSearchChange = (value: string) => {
+    setSearchQuery(value);
+    if (currentPage !== 1) {
+      setCurrentPage(1);
+    }
+  };
+
+  const handleClearSearch = () => {
+    setSearchQuery('');
+    setCurrentPage(1);
+  };
+
+  const handleOpenRoleModal = (user: AdminUserResponse) => {
+    setSelectedUser(user);
+    setShowRoleModal(true);
+  };
+
+  const handleRefresh = async () => {
+    if (!session?.accessToken) return;
+
+    resetUserCache();
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+
+    await Promise.all([
+      fetchRoles(),
+      trimmedSearchQuery ? searchUsers(trimmedSearchQuery, requestId) : fetchUsers(requestId),
+    ]);
+  };
 
   return (
     <div className="p-6 md:p-8">
-      <div className="mx-auto max-w-4xl">
-        {/* 헤더 */}
-        <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="mx-auto max-w-7xl">
+        <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
           <div>
-            <h1 className="text-xl font-bold text-gray-900">회원 관리</h1>
-            <p className="mt-0.5 text-sm text-gray-500">
+            <h1 className="text-xl font-bold text-gray-900">사용자 관리</h1>
+            <p className="mt-1 text-sm text-gray-500">
               {isSearchMode
-                ? `검색 ${totalItems.toLocaleString()}명`
-                : `전체 ${totalItems.toLocaleString()}명 · 활성 ${activeCount.toLocaleString()}명`}
+                ? `검색 결과 ${totalItems.toLocaleString()}명`
+                : `전체 ${totalItems.toLocaleString()}명 · 현재 표시 ${visibleCount.toLocaleString()}명 · 활성 ${activeVisibleCount.toLocaleString()}명`}
             </p>
           </div>
 
-          {/* 검색 및 필터 */}
-          <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:items-center">
-            <label className="flex cursor-pointer items-center gap-2 text-sm text-gray-600">
+          <div className="flex w-full flex-col gap-3 lg:w-auto lg:min-w-[440px]">
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <div className="relative flex-1">
+                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+                <input
+                  type="text"
+                  placeholder="이름, 이메일, 학번 검색"
+                  value={searchQuery}
+                  onChange={(e) => handleSearchChange(e.target.value)}
+                  className="w-full rounded-lg border border-gray-200 bg-white py-2.5 pl-9 pr-9 text-sm transition-colors focus:border-gray-400 focus:outline-none"
+                />
+                {trimmedSearchQuery && (
+                  <button
+                    type="button"
+                    onClick={handleClearSearch}
+                    className="absolute right-2 top-1/2 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700"
+                    aria-label="검색어 지우기"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={handleRefresh}
+                className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+              >
+                <RefreshCcw className="h-4 w-4" />
+                새로고침
+              </button>
+            </div>
+            <label className="inline-flex cursor-pointer items-center gap-2 text-sm text-gray-600">
               <input
                 type="checkbox"
                 checked={excludeDeleted}
@@ -301,21 +401,15 @@ export default function AdminUsersPage() {
               />
               탈퇴 회원 제외
             </label>
-            <div className="relative w-full sm:w-72">
-              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
-              <input
-                type="text"
-                placeholder="이름, 이메일, 학번 검색"
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                className="w-full rounded-lg border border-gray-200 bg-white py-2 pl-9 pr-3 text-sm transition-colors focus:border-gray-400 focus:outline-none"
-              />
-            </div>
           </div>
         </div>
 
-        {/* 회원 목록 */}
         <div className="overflow-hidden rounded-xl border border-gray-200 bg-white">
+          <div className="flex flex-col gap-1 border-b border-gray-200 px-4 py-3 text-sm text-gray-500 sm:flex-row sm:items-center sm:justify-between">
+            <span>{trimmedSearchQuery ? `검색어: ${trimmedSearchQuery}` : '사용자 목록'}</span>
+            <span>{excludeDeleted ? '탈퇴 회원 제외 적용됨' : '전체 사용자 표시 중'}</span>
+          </div>
+
           {isLoading ? (
             <div className="py-16 text-center">
               <Loader2 className="mx-auto h-6 w-6 animate-spin text-gray-400" />
@@ -325,96 +419,161 @@ export default function AdminUsersPage() {
             <div className="py-16 text-center">
               <Users className="mx-auto h-8 w-8 text-gray-300" />
               <p className="mt-2 text-sm text-gray-500">
-                {searchQuery ? '검색 결과가 없습니다' : '회원이 없습니다'}
+                {trimmedSearchQuery ? '검색 결과가 없습니다' : '회원이 없습니다'}
               </p>
             </div>
           ) : (
-            <ul className="divide-y divide-gray-100">
-              {filteredUsers.map((user) => (
-                <li key={user.id} className="flex items-center gap-4 px-5 py-4 transition-colors hover:bg-gray-50">
-                  <Link href={`/admin/users/list/${user.id}`}>
-                    {user.profileImageUrl ? (
-                      <Image
-                        src={ensureEncodedUrl(user.profileImageUrl)}
-                        alt={user.name}
-                        width={36}
-                        height={36}
-                        className="h-9 w-9 shrink-0 rounded-full object-cover hover:ring-2 hover:ring-gray-300 transition-all"
-                      />
-                    ) : (
-                      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-gray-900 text-sm font-medium text-white hover:ring-2 hover:ring-gray-300 transition-all">
-                        {user.name[0]}
-                      </div>
-                    )}
-                  </Link>
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
-                      <Link href={`/admin/users/list/${user.id}`} className="truncate font-medium text-gray-900 hover:underline">{user.name}</Link>
-                      {user.isDeleted ? (
-                        <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500">탈퇴</span>
-                      ) : (
-                        <span className="shrink-0 rounded-full bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700">활성</span>
-                      )}
-                    </div>
-                    <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-gray-500">
-                      <span>{user.kutId}</span>
-                      <span>{user.kutEmail}</span>
-                      <span>{formatDate(user.createdAt)}</span>
-                      {user.roles.length > 0 && (
-                        <div className="flex gap-1">
-                          {user.roles.slice(0, 2).map((role) => (
-                            <span key={role} className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-600">
-                              {role.replace('ROLE_', '')}
-                            </span>
-                          ))}
-                          {user.roles.length > 2 && (
-                            <span className="text-gray-400">+{user.roles.length - 2}</span>
-                          )}
+            <>
+              <div className="hidden md:block overflow-x-auto">
+                <table className="min-w-full">
+                  <thead className="bg-gray-50">
+                    <tr className="text-left text-xs font-semibold uppercase tracking-wider text-gray-500">
+                      <th className="px-4 py-3">사용자</th>
+                      <th className="px-4 py-3">학번/사번</th>
+                      <th className="px-4 py-3">이메일</th>
+                      <th className="px-4 py-3">가입일</th>
+                      <th className="px-4 py-3">역할</th>
+                      <th className="px-4 py-3">상태</th>
+                      <th className="px-4 py-3 text-right">작업</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100">
+                    {filteredUsers.map((user) => (
+                      <tr key={user.id} className="hover:bg-gray-50">
+                        <td className="px-4 py-3">
+                          <div className="flex items-center gap-3">
+                            <Link href={`/admin/users/list/${user.id}`} className="shrink-0">
+                              <UserAvatar name={user.name} profileImageUrl={user.profileImageUrl} />
+                            </Link>
+                            <Link
+                              href={`/admin/users/list/${user.id}`}
+                              className="truncate font-medium text-gray-900 hover:underline"
+                            >
+                              {user.name}
+                            </Link>
+                          </div>
+                        </td>
+                        <td className="px-4 py-3 text-sm text-gray-600">{user.kutId}</td>
+                        <td className="px-4 py-3 text-sm text-gray-600">{user.kutEmail}</td>
+                        <td className="px-4 py-3 text-sm text-gray-600">{formatDate(user.createdAt)}</td>
+                        <td className="px-4 py-3">
+                          <div className="flex flex-wrap gap-1">
+                            {user.roles.length > 0 ? (
+                              user.roles.slice(0, 2).map((role) => (
+                                <span
+                                  key={role}
+                                  className="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-600"
+                                >
+                                  {getRoleLabel(role)}
+                                </span>
+                              ))
+                            ) : (
+                              <span className="text-xs text-gray-400">-</span>
+                            )}
+                            {user.roles.length > 2 && (
+                              <span className="text-xs text-gray-400">+{user.roles.length - 2}</span>
+                            )}
+                          </div>
+                        </td>
+                        <td className="px-4 py-3">
+                          <UserStatusBadge isDeleted={user.isDeleted} />
+                        </td>
+                        <td className="px-4 py-3">
+                          <div className="flex justify-end gap-2">
+                            <Link
+                              href={`/admin/users/list/${user.id}`}
+                              className="inline-flex items-center gap-1 rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-50"
+                            >
+                              <SquarePen className="h-3.5 w-3.5" />
+                              수정
+                            </Link>
+                            <button
+                              onClick={() => handleOpenRoleModal(user)}
+                              className="rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-50"
+                            >
+                              역할
+                            </button>
+                            <button
+                              onClick={() => handleDeleteClick(user)}
+                              disabled={user.isDeleted || isDeleting}
+                              className="rounded-lg bg-red-500 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-red-600 disabled:cursor-not-allowed disabled:opacity-50"
+                            >
+                              탈퇴
+                            </button>
+                          </div>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              <ul className="divide-y divide-gray-100 md:hidden">
+                {filteredUsers.map((user) => (
+                  <li key={user.id} className="space-y-3 px-4 py-4">
+                    <div className="flex items-start gap-3">
+                      <Link href={`/admin/users/list/${user.id}`} className="shrink-0">
+                        <UserAvatar name={user.name} profileImageUrl={user.profileImageUrl} />
+                      </Link>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2">
+                          <Link
+                            href={`/admin/users/list/${user.id}`}
+                            className="truncate font-medium text-gray-900 hover:underline"
+                          >
+                            {user.name}
+                          </Link>
+                          <UserStatusBadge isDeleted={user.isDeleted} />
                         </div>
+                        <div className="mt-1 space-y-1 text-xs text-gray-500">
+                          <p>{user.kutId}</p>
+                          <p className="truncate">{user.kutEmail}</p>
+                          <p>{formatDate(user.createdAt)}</p>
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="flex flex-wrap gap-1">
+                      {user.roles.length > 0 ? (
+                        user.roles.map((role) => (
+                          <span key={role} className="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
+                            {getRoleLabel(role)}
+                          </span>
+                        ))
+                      ) : (
+                        <span className="text-xs text-gray-400">역할 없음</span>
                       )}
                     </div>
-                  </div>
-                  <div className="flex shrink-0 items-center gap-2">
-                    <Link
-                      href={`/admin/users/list/${user.id}`}
-                      className="inline-flex items-center gap-1 rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-50"
-                    >
-                      <SquarePen className="h-3.5 w-3.5" />
-                      수정
-                    </Link>
-                    <button
-                      onClick={() => {
-                        setSelectedUser(user);
-                        setShowRoleModal(true);
-                      }}
-                      className="rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-50"
-                    >
-                      역할
-                    </button>
-                    <span className="group relative">
+
+                    <div className="flex gap-2">
+                      <Link
+                        href={`/admin/users/list/${user.id}`}
+                        className="inline-flex flex-1 items-center justify-center gap-1 rounded-lg border border-gray-200 px-3 py-2 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-50"
+                      >
+                        <SquarePen className="h-3.5 w-3.5" />
+                        수정
+                      </Link>
+                      <button
+                        onClick={() => handleOpenRoleModal(user)}
+                        className="flex-1 rounded-lg border border-gray-200 px-3 py-2 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-50"
+                      >
+                        역할
+                      </button>
                       <button
                         onClick={() => handleDeleteClick(user)}
                         disabled={user.isDeleted || isDeleting}
-                        className="rounded-lg bg-red-500 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-red-600 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50"
+                        className="flex-1 rounded-lg bg-red-500 px-3 py-2 text-xs font-medium text-white transition-colors hover:bg-red-600 disabled:cursor-not-allowed disabled:opacity-50"
                       >
                         탈퇴
                       </button>
-                      {user.isDeleted && (
-                        <div className="pointer-events-none absolute bottom-full right-0 mb-2 whitespace-nowrap rounded bg-gray-900 px-2 py-1 text-xs text-white opacity-0 transition-opacity group-hover:opacity-100">
-                          탈퇴 처리된 회원입니다.
-                          <div className="absolute right-3 top-full border-4 border-transparent border-t-gray-900" />
-                        </div>
-                      )}
-                    </span>
-                  </div>
-                </li>
-              ))}
-            </ul>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </>
           )}
-
         </div>
 
-        {/* 페이지네이션 */}
         {!isSearchMode && filteredUsers.length > 0 && (
           <div className="mt-4">
             <Pagination
@@ -425,7 +584,6 @@ export default function AdminUsersPage() {
           </div>
         )}
 
-        {/* 역할 관리 모달 */}
         {showRoleModal && selectedUser && (
           <UserRoleModal
             user={selectedUser}
@@ -435,14 +593,12 @@ export default function AdminUsersPage() {
           />
         )}
 
-        {/* 삭제 확인 모달 */}
         {showDeleteModal && selectedUser && (
           <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
             <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl">
               <h2 className="mb-4 text-xl font-bold text-gray-900">회원 탈퇴</h2>
               <p className="mb-6 text-gray-600">
-                <span className="font-semibold">{selectedUser.name}</span>님을 강제 탈퇴
-                처리하시겠습니까?
+                <span className="font-semibold">{selectedUser.name}</span>님을 강제 탈퇴 처리하시겠습니까?
                 <br />
                 이 작업은 되돌릴 수 없습니다.
               </p>
@@ -511,7 +667,6 @@ function UserRoleModal({
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
       <div className="w-full max-w-md rounded-xl bg-white shadow-xl">
-        {/* 헤더 */}
         <div className="flex items-center justify-between border-b border-gray-200 px-5 py-4">
           <div>
             <h2 className="font-semibold text-gray-900">역할 관리</h2>
@@ -525,7 +680,6 @@ function UserRoleModal({
           </button>
         </div>
 
-        {/* 역할 목록 */}
         <div className="max-h-[60vh] overflow-y-auto p-5">
           <div className="space-y-2">
             {allRoles.map((role, index) => {
@@ -566,7 +720,6 @@ function UserRoleModal({
           </div>
         </div>
 
-        {/* 푸터 */}
         <div className="flex gap-2 border-t border-gray-200 px-5 py-4">
           <button
             onClick={onClose}

--- a/src/common/components/SpelEditor/index.tsx
+++ b/src/common/components/SpelEditor/index.tsx
@@ -15,8 +15,8 @@ const Editor = dynamic(() => import('@monaco-editor/react'), {
   ),
 });
 
-// Python을 SpEL로 변환하는 함수 (0~100% 백분율 표현식)
-function pythonToSpel(python: string): string {
+// Python을 기본 SpEL로 변환하는 함수 (fallback 용도)
+function pythonToBasicSpel(python: string): string {
   if (!python.trim()) return '';
 
   let spel = python;
@@ -68,6 +68,124 @@ function combinePercentages(parts: string[], operation: 'min' | 'max'): string {
   return result;
 }
 
+function stripOuterParentheses(expr: string): string {
+  let stripped = expr.trim();
+
+  while (stripped.startsWith('(') && stripped.endsWith(')')) {
+    let depth = 0;
+    let isWrapped = true;
+
+    for (let i = 0; i < stripped.length; i++) {
+      if (stripped[i] === '(') depth++;
+      else if (stripped[i] === ')') depth--;
+
+      if (depth === 0 && i < stripped.length - 1) {
+        isWrapped = false;
+        break;
+      }
+    }
+
+    if (!isWrapped) break;
+    stripped = stripped.slice(1, -1).trim();
+  }
+
+  return stripped;
+}
+
+function splitFunctionArgsTopLevel(argsStr: string): string[] {
+  const args: string[] = [];
+  let depth = 0;
+  let current = '';
+
+  for (let i = 0; i < argsStr.length; i++) {
+    const char = argsStr[i];
+
+    if (char === '(') {
+      depth++;
+      current += char;
+      continue;
+    }
+
+    if (char === ')') {
+      depth--;
+      current += char;
+      continue;
+    }
+
+    if (char === ',' && depth === 0) {
+      if (current.trim()) {
+        args.push(current.trim());
+      }
+      current = '';
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (current.trim()) {
+    args.push(current.trim());
+  }
+
+  return args;
+}
+
+function getFunctionArgs(expr: string, functionNames: string[]): string[] | null {
+  const trimmed = expr.trim();
+
+  for (const functionName of functionNames) {
+    const prefix = `${functionName}(`;
+    if (!trimmed.startsWith(prefix) || !trimmed.endsWith(')')) {
+      continue;
+    }
+
+    let depth = 0;
+    let isWholeFunction = true;
+    let sawOpenParen = false;
+    for (let i = 0; i < trimmed.length; i++) {
+      if (trimmed[i] === '(') {
+        depth++;
+        sawOpenParen = true;
+      } else if (trimmed[i] === ')') {
+        depth--;
+      }
+
+      if (sawOpenParen && depth === 0 && i < trimmed.length - 1) {
+        isWholeFunction = false;
+        break;
+      }
+    }
+
+    if (!isWholeFunction) {
+      continue;
+    }
+
+    const argsString = trimmed.slice(prefix.length, -1);
+    return splitFunctionArgsTopLevel(argsString);
+  }
+
+  return null;
+}
+
+function parseProgressExpression(expr: string): string | null {
+  const args = getFunctionArgs(expr, ['min', 'T(Math).min']);
+  if (!args || args.length !== 2) return null;
+
+  const leftArg = stripOuterParentheses(args[0]);
+  const rightArg = stripOuterParentheses(args[1]);
+  if (!/^100(?:\.0+)?$/.test(rightArg)) return null;
+
+  const progressPattern = new RegExp(
+    `^(${VAR_PATTERN})\\s*\\*\\s*100(?:\\.0+)?\\s*\\/\\s*(\\d+(?:\\.\\d+)?)$`
+  );
+  const match = leftArg.match(progressPattern);
+
+  if (!match) return null;
+
+  const [, variable, target] = match;
+  return `#progress(${variable}, ${target})`;
+}
+
 // 최상위 레벨에서 연산자로 분리 (괄호 내부는 무시)
 function splitByOperatorTopLevel(expr: string, operator: string): string[] {
   const parts: string[] = [];
@@ -111,26 +229,12 @@ function splitByOperatorTopLevel(expr: string, operator: string): string[] {
 // 표현식을 재귀적으로 백분율 SpEL로 변환
 // 우선순위: 괄호 > AND > OR
 function parseExpression(expr: string): string | null {
-  expr = expr.trim();
+  expr = stripOuterParentheses(expr);
   if (!expr) return null;
 
-  // 전체가 괄호로 감싸져 있으면 벗기고 재귀
-  if (expr.startsWith('(') && expr.endsWith(')')) {
-    // 실제로 매칭되는 괄호인지 확인
-    let depth = 0;
-    let isWrapped = true;
-    for (let i = 0; i < expr.length; i++) {
-      if (expr[i] === '(') depth++;
-      else if (expr[i] === ')') depth--;
-      // 중간에 depth가 0이 되면 전체를 감싸는 괄호가 아님
-      if (depth === 0 && i < expr.length - 1) {
-        isWrapped = false;
-        break;
-      }
-    }
-    if (isWrapped) {
-      return parseExpression(expr.slice(1, -1));
-    }
+  const progressExpression = parseProgressExpression(expr);
+  if (progressExpression) {
+    return progressExpression;
   }
 
   // 1단계: OR로 분리 (가장 낮은 우선순위)
@@ -156,7 +260,34 @@ function parseExpression(expr: string): string | null {
   }
 
   // 3단계: 단일 조건
-  return conditionToPercentage(expr);
+  const directCondition = conditionToPercentage(expr);
+  if (directCondition) {
+    return directCondition;
+  }
+
+  const minArgs = getFunctionArgs(expr, ['min', 'T(Math).min']);
+  if (minArgs && minArgs.length > 0) {
+    const minPercentages = minArgs
+      .map((part) => parseExpression(part))
+      .filter((part): part is string => part !== null);
+
+    if (minPercentages.length === minArgs.length) {
+      return combinePercentages(minPercentages, 'min');
+    }
+  }
+
+  const maxArgs = getFunctionArgs(expr, ['max', 'T(Math).max']);
+  if (maxArgs && maxArgs.length > 0) {
+    const maxPercentages = maxArgs
+      .map((part) => parseExpression(part))
+      .filter((part): part is string => part !== null);
+
+    if (maxPercentages.length === maxArgs.length) {
+      return combinePercentages(maxPercentages, 'max');
+    }
+  }
+
+  return null;
 }
 
 // 조건식을 백분율 반환 SpEL로 변환 (0~100)
@@ -165,14 +296,18 @@ function parseExpression(expr: string): string | null {
 function toPercentageSpel(python: string): string {
   if (!python.trim()) return '';
 
-  // 먼저 기본 SpEL 변환 (and → &&, or → ||)
-  const spel = pythonToSpel(python);
+  const normalizedPython = python
+    .replace(/\band\b/g, '&&')
+    .replace(/\bor\b/g, '||')
+    .replace(/\bnot\s+/g, '!')
+    .replace(/\bTrue\b/g, 'true')
+    .replace(/\bFalse\b/g, 'false');
 
   // 재귀적으로 파싱
-  const result = parseExpression(spel);
+  const result = parseExpression(normalizedPython);
 
   // 패턴 매칭 실패 시 기본 SpEL 반환
-  return result || spel;
+  return result || pythonToBasicSpel(python);
 }
 
 // 조건의 의미를 백분율로 해석


### PR DESCRIPTION
## 작업 내용
- 관리자 사용자 목록과 포인트 목록 화면을 과한 카드형 구성 없이 단순한 표 중심 레이아웃으로 정리했습니다.
- 관리자 포인트 상세 화면을 단순화하고, 회수 시 현재 잔액을 초과하지 못하도록 막았으며 이력 새로고침 버튼을 추가했습니다.
- 사용자 수정 화면의 `KUT 이메일` 표기를 `아우누리 이메일`로 변경했습니다.
- 챌린지 조건식 예시 입력의 SpEL 변환을 `#progress`, `#min`, `#max` 형식에 맞게 개선했습니다.

## 검증
- `./node_modules/.bin/eslint src/common/components/SpelEditor/index.tsx src/app/admin/users/list/page.tsx 'src/app/admin/users/list/[id]/page.tsx' src/app/admin/points/page.tsx 'src/app/admin/points/[userId]/page.tsx'`
- `./node_modules/.bin/tsc --noEmit`
