### PR TITLE
관리자 검색 안내 및 깃허브 기여 카드 표시 수정

### DIFF
--- a/src/app/admin/points/page.tsx
+++ b/src/app/admin/points/page.tsx
@@ -5,8 +5,8 @@ import { useRouter } from 'next/navigation';
 import { useSession } from '@/lib/auth/AuthContext';
 import Image from 'next/image';
 import { Search, Users, Loader2, Coins, RefreshCcw, X } from 'lucide-react';
-import { adminSearch, getAdminUsers } from '@/lib/api/admin';
-import type { AdminSearchUserSummary, AdminUserResponse } from '@/types/admin';
+import { getAdminUsers } from '@/lib/api/admin';
+import type { AdminUserResponse } from '@/types/admin';
 import { toast } from '@/lib/toast';
 import Pagination from '@/common/components/Pagination';
 import { ensureEncodedUrl } from '@/lib/utils';
@@ -57,6 +57,18 @@ function UserStatusBadge({ isDeleted }: { isDeleted: boolean }) {
     <span className="inline-flex rounded-full bg-green-50 px-2.5 py-1 text-xs font-medium text-green-700">
       활성
     </span>
+  );
+}
+
+function matchesUserSearch(user: AdminUserResponse, keyword: string): boolean {
+  const normalizedKeyword = keyword.trim().toLowerCase();
+
+  if (!normalizedKeyword) {
+    return true;
+  }
+
+  return [user.name, user.kutId, user.kutEmail].some((value) =>
+    value.toLowerCase().includes(normalizedKeyword)
   );
 }
 
@@ -133,46 +145,40 @@ export default function AdminPointsPage() {
     }
   }, [currentPage, fetchUserPage, session?.accessToken]);
 
-  const hydrateSearchUsers = useCallback(async (searchUsers: AdminSearchUserSummary[]) => {
-    const searchIds = searchUsers.map((user) => user.id);
-    let missingIds = searchIds.filter((id) => !userCacheRef.current.has(id));
-    let page = 1;
+  const ensureAllUsersLoaded = useCallback(async () => {
+    if (!session?.accessToken) return;
 
-    while (missingIds.length > 0) {
-      const knownTotalPages = knownTotalPagesRef.current;
-      if (knownTotalPages !== null && page > knownTotalPages) break;
+    if (!loadedPagesRef.current.has(1)) {
+      await fetchUserPage(1);
+    }
 
+    const totalPageCount = knownTotalPagesRef.current ?? 1;
+
+    for (let page = 1; page <= totalPageCount; page += 1) {
       if (loadedPagesRef.current.has(page)) {
-        page += 1;
         continue;
       }
 
       await fetchUserPage(page);
-      missingIds = searchIds.filter((id) => !userCacheRef.current.has(id));
-      page += 1;
     }
-
-    return searchUsers
-      .map((user) => userCacheRef.current.get(user.id))
-      .filter((user): user is AdminUserResponse => Boolean(user));
-  }, [fetchUserPage]);
+  }, [fetchUserPage, session?.accessToken]);
 
   const searchUsers = useCallback(async (keyword: string, requestId: number) => {
     if (!session?.accessToken) return;
 
     setIsLoading(true);
     try {
-      const searchData = await adminSearch(keyword, 'USER', { accessToken: session.accessToken });
+      await ensureAllUsersLoaded();
 
       if (requestId !== requestIdRef.current) return;
 
-      const hydratedUsers = await hydrateSearchUsers(searchData.users || []);
+      const matchedUsers = Array.from(userCacheRef.current.values()).filter((user) =>
+        matchesUserSearch(user, keyword)
+      );
 
-      if (requestId !== requestIdRef.current) return;
-
-      setUsers(hydratedUsers);
+      setUsers(matchedUsers);
       setTotalPages(1);
-      setTotalItems(hydratedUsers.length);
+      setTotalItems(matchedUsers.length);
     } catch (err) {
       if (requestId !== requestIdRef.current) return;
 
@@ -186,7 +192,7 @@ export default function AdminPointsPage() {
         setIsLoading(false);
       }
     }
-  }, [hydrateSearchUsers, session?.accessToken]);
+  }, [ensureAllUsersLoaded, session?.accessToken]);
 
   useEffect(() => {
     if (status === 'authenticated' && session?.accessToken) {
@@ -275,7 +281,7 @@ export default function AdminPointsPage() {
                 <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
                 <input
                   type="text"
-                  placeholder="이름, 이메일, 학번 검색"
+                  placeholder="이름으로 검색"
                   value={searchQuery}
                   onChange={(e) => handleSearchChange(e.target.value)}
                   className="w-full rounded-lg border border-gray-200 bg-white py-2.5 pl-9 pr-9 text-sm transition-colors focus:border-gray-400 focus:outline-none"
@@ -309,6 +315,9 @@ export default function AdminPointsPage() {
               />
               탈퇴 회원 제외
             </label>
+            <p className="text-xs text-gray-500">
+              현재 사용자 검색은 이름 기준으로만 지원합니다.
+            </p>
           </div>
         </div>
 

--- a/src/app/admin/users/list/page.tsx
+++ b/src/app/admin/users/list/page.tsx
@@ -6,8 +6,8 @@ import Link from 'next/link';
 import { useSession } from '@/lib/auth/AuthContext';
 import Image from 'next/image';
 import { Search, Users, X, Check, Loader2, SquarePen, RefreshCcw } from 'lucide-react';
-import { adminSearch, getAdminUsers, getRoles, updateUserRoles, deleteAdminUser } from '@/lib/api/admin';
-import type { AdminSearchUserSummary, AdminUserResponse, RoleResponse } from '@/types/admin';
+import { getAdminUsers, getRoles, updateUserRoles, deleteAdminUser } from '@/lib/api/admin';
+import type { AdminUserResponse, RoleResponse } from '@/types/admin';
 import { toast } from '@/lib/toast';
 import Pagination from '@/common/components/Pagination';
 import { ensureEncodedUrl } from '@/lib/utils';
@@ -62,6 +62,18 @@ function UserStatusBadge({ isDeleted }: { isDeleted: boolean }) {
     <span className="inline-flex rounded-full bg-green-50 px-2.5 py-1 text-xs font-medium text-green-700">
       활성
     </span>
+  );
+}
+
+function matchesUserSearch(user: AdminUserResponse, keyword: string): boolean {
+  const normalizedKeyword = keyword.trim().toLowerCase();
+
+  if (!normalizedKeyword) {
+    return true;
+  }
+
+  return [user.name, user.kutId, user.kutEmail].some((value) =>
+    value.toLowerCase().includes(normalizedKeyword)
   );
 }
 
@@ -155,46 +167,40 @@ export default function AdminUsersPage() {
     }
   }, [currentPage, fetchUserPage, session?.accessToken]);
 
-  const hydrateSearchUsers = useCallback(async (searchUsers: AdminSearchUserSummary[]) => {
-    const searchIds = searchUsers.map((user) => user.id);
-    let missingIds = searchIds.filter((id) => !userCacheRef.current.has(id));
-    let page = 1;
+  const ensureAllUsersLoaded = useCallback(async () => {
+    if (!session?.accessToken) return;
 
-    while (missingIds.length > 0) {
-      const knownTotalPages = knownTotalPagesRef.current;
-      if (knownTotalPages !== null && page > knownTotalPages) break;
+    if (!loadedPagesRef.current.has(1)) {
+      await fetchUserPage(1);
+    }
 
+    const totalPageCount = knownTotalPagesRef.current ?? 1;
+
+    for (let page = 1; page <= totalPageCount; page += 1) {
       if (loadedPagesRef.current.has(page)) {
-        page += 1;
         continue;
       }
 
       await fetchUserPage(page);
-      missingIds = searchIds.filter((id) => !userCacheRef.current.has(id));
-      page += 1;
     }
-
-    return searchUsers
-      .map((user) => userCacheRef.current.get(user.id))
-      .filter((user): user is AdminUserResponse => Boolean(user));
-  }, [fetchUserPage]);
+  }, [fetchUserPage, session?.accessToken]);
 
   const searchUsers = useCallback(async (keyword: string, requestId: number) => {
     if (!session?.accessToken) return;
 
     setIsLoading(true);
     try {
-      const searchData = await adminSearch(keyword, 'USER', { accessToken: session.accessToken });
+      await ensureAllUsersLoaded();
 
       if (requestId !== requestIdRef.current) return;
 
-      const hydratedUsers = await hydrateSearchUsers(searchData.users || []);
+      const matchedUsers = Array.from(userCacheRef.current.values()).filter((user) =>
+        matchesUserSearch(user, keyword)
+      );
 
-      if (requestId !== requestIdRef.current) return;
-
-      setUsers(hydratedUsers);
+      setUsers(matchedUsers);
       setTotalPages(1);
-      setTotalItems(hydratedUsers.length);
+      setTotalItems(matchedUsers.length);
     } catch (err) {
       if (requestId !== requestIdRef.current) return;
 
@@ -208,7 +214,7 @@ export default function AdminUsersPage() {
         setIsLoading(false);
       }
     }
-  }, [hydrateSearchUsers, session?.accessToken]);
+  }, [ensureAllUsersLoaded, session?.accessToken]);
 
   useEffect(() => {
     if (status === 'authenticated' && session?.accessToken) {
@@ -367,7 +373,7 @@ export default function AdminUsersPage() {
                 <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
                 <input
                   type="text"
-                  placeholder="이름, 이메일, 학번 검색"
+                  placeholder="이름으로 검색"
                   value={searchQuery}
                   onChange={(e) => handleSearchChange(e.target.value)}
                   className="w-full rounded-lg border border-gray-200 bg-white py-2.5 pl-9 pr-9 text-sm transition-colors focus:border-gray-400 focus:outline-none"
@@ -401,6 +407,9 @@ export default function AdminUsersPage() {
               />
               탈퇴 회원 제외
             </label>
+            <p className="text-xs text-gray-500">
+              현재 사용자 검색은 이름 기준으로만 지원합니다.
+            </p>
           </div>
         </div>
 

--- a/src/app/user/UserPageClient.tsx
+++ b/src/app/user/UserPageClient.tsx
@@ -115,6 +115,7 @@ export default function UserPageClient({ session }: UserPageClientProps) {
   const [counts, setCounts] = useState({ posts: 0, comments: 0, bookmarks: 0 });
   const [isLoading, setIsLoading] = useState(true);
   const [showAllRepos, setShowAllRepos] = useState(false);
+  const recentRepositoryCount = recentActivity.length;
 
   // 지원내역 모달 상태
   const [selectedApplication, setSelectedApplication] = useState<MyApplicationResponse | null>(null);
@@ -179,7 +180,7 @@ export default function UserPageClient({ session }: UserPageClientProps) {
     };
 
     fetchInitialData();
-  }, [userId, fetchGithubData]);
+  }, [userId, accessToken, fetchGithubData]);
 
   useEffect(() => {
     if (!userId) return;
@@ -493,7 +494,7 @@ export default function UserPageClient({ session }: UserPageClientProps) {
                         commits: overallHistory.totalCommitCount,
                         pullRequests: overallHistory.totalPrCount,
                         issues: overallHistory.totalIssueCount,
-                        repositories: overallHistory.contributedRepoCount,
+                        repositories: recentRepositoryCount,
                       }}
                     />
                   )}
@@ -586,9 +587,9 @@ export default function UserPageClient({ session }: UserPageClientProps) {
                         <div className="flex flex-col items-center justify-center p-4 transition-colors hover:bg-gray-50 sm:p-5">
                           <FolderGit className="mb-1.5 h-5 w-5 text-gray-400" />
                           <div className="text-xl font-bold text-gray-900 sm:text-2xl">
-                            {overallHistory.contributedRepoCount.toLocaleString()}
+                            {recentRepositoryCount.toLocaleString()}
                           </div>
-                          <div className="text-[10px] uppercase tracking-wider text-gray-500 sm:text-xs">Repositories</div>
+                          <div className="text-[10px] uppercase tracking-wider text-gray-500 sm:text-xs">Recent Repos</div>
                         </div>
                         <div className="flex flex-col items-center justify-center p-4 transition-colors hover:bg-gray-50 sm:p-5">
                           <TrendingUp className="mb-1.5 h-5 w-5 text-emerald-500" />

--- a/src/app/user/[id]/UserProfileClient.tsx
+++ b/src/app/user/[id]/UserProfileClient.tsx
@@ -74,6 +74,7 @@ export default function UserProfileClient({
   const [counts, setCounts] = useState(initialCounts);
   const [isLoading, setIsLoading] = useState(true);
   const [showAllRepos, setShowAllRepos] = useState(false);
+  const recentRepositoryCount = recentActivity.length;
 
   const fetchGithubData = useCallback(async () => {
     const [historyRes, activityRes, scoreRes, comparisonRes] = await Promise.all([
@@ -333,7 +334,7 @@ export default function UserProfileClient({
                         commits: overallHistory.totalCommitCount,
                         pullRequests: overallHistory.totalPrCount,
                         issues: overallHistory.totalIssueCount,
-                        repositories: overallHistory.contributedRepoCount,
+                        repositories: recentRepositoryCount,
                       }}
                     />
                   )}
@@ -426,9 +427,9 @@ export default function UserProfileClient({
                         <div className="flex flex-col items-center justify-center p-4 transition-colors hover:bg-gray-50 sm:p-5">
                           <FolderGit className="mb-1.5 h-5 w-5 text-gray-400" />
                           <div className="text-xl font-bold text-gray-900 sm:text-2xl">
-                            {overallHistory.contributedRepoCount.toLocaleString()}
+                            {recentRepositoryCount.toLocaleString()}
                           </div>
-                          <div className="text-[10px] uppercase tracking-wider text-gray-500 sm:text-xs">Repositories</div>
+                          <div className="text-[10px] uppercase tracking-wider text-gray-500 sm:text-xs">Recent Repos</div>
                         </div>
                         <div className="flex flex-col items-center justify-center p-4 transition-colors hover:bg-gray-50 sm:p-5">
                           <TrendingUp className="mb-1.5 h-5 w-5 text-emerald-500" />

--- a/src/common/components/GithubRankCard/index.tsx
+++ b/src/common/components/GithubRankCard/index.tsx
@@ -275,12 +275,12 @@ export default function GithubRankCard({
             {/* Rank */}
             <div className="z-10 text-left sm:text-right" style={{ transform: 'translateZ(30px)' }}>
               <div className="mb-1 flex items-center gap-1.5 sm:justify-end">
-                <span className="text-[10px] font-semibold uppercase tracking-[0.2em] text-slate-500 sm:text-xs">
+                <span className="text-[10px] font-semibold uppercase tracking-[0.2em] text-white/80 sm:text-xs">
                   Current Rank
                 </span>
                 <button
                   onClick={() => setShowTierInfo(true)}
-                  className="rounded-full p-0.5 text-slate-500 transition-colors hover:bg-white/10 hover:text-slate-300"
+                  className="rounded-full p-0.5 text-white/80 transition-colors hover:bg-white/10 hover:text-white"
                   aria-label="티어 기준 보기"
                 >
                   <HelpCircle className="h-3.5 w-3.5 sm:h-4 sm:w-4" />
@@ -295,7 +295,7 @@ export default function GithubRankCard({
               >
                 {data.title}
               </div>
-              <div className="mt-1 text-xs font-light text-slate-400 sm:text-sm">
+              <div className="mt-1 text-xs font-light text-white/80 sm:text-sm">
                 <span className="font-medium text-white">{data.percent}</span> of developers
               </div>
             </div>
@@ -311,7 +311,7 @@ export default function GithubRankCard({
               <span className="text-lg font-bold text-white sm:text-xl">
                 {stats.commits.toLocaleString()}
               </span>
-              <span className="text-[10px] uppercase tracking-wider text-slate-500 sm:text-xs">
+              <span className="text-[10px] uppercase tracking-wider text-white/80 sm:text-xs">
                 Commits
               </span>
             </div>
@@ -320,7 +320,7 @@ export default function GithubRankCard({
               <span className="text-lg font-bold text-white sm:text-xl">
                 {stats.pullRequests.toLocaleString()}
               </span>
-              <span className="text-[10px] uppercase tracking-wider text-slate-500 sm:text-xs">
+              <span className="text-[10px] uppercase tracking-wider text-white/80 sm:text-xs">
                 Pull Requests
               </span>
             </div>
@@ -329,7 +329,7 @@ export default function GithubRankCard({
               <span className="text-lg font-bold text-white sm:text-xl">
                 {stats.issues.toLocaleString()}
               </span>
-              <span className="text-[10px] uppercase tracking-wider text-slate-500 sm:text-xs">
+              <span className="text-[10px] uppercase tracking-wider text-white/80 sm:text-xs">
                 Issues
               </span>
             </div>
@@ -338,8 +338,8 @@ export default function GithubRankCard({
               <span className="text-lg font-bold text-white sm:text-xl">
                 {stats.repositories.toLocaleString()}
               </span>
-              <span className="text-[10px] uppercase tracking-wider text-slate-500 sm:text-xs">
-                Repositories
+              <span className="text-[10px] uppercase tracking-wider text-white/80 sm:text-xs">
+                Recent Repos
               </span>
             </div>
           </div>
@@ -350,7 +350,7 @@ export default function GithubRankCard({
             style={{ transform: 'translateZ(20px)' }}
           >
             <div className="mb-3 flex justify-between text-xs sm:text-sm">
-              <span className="text-slate-400">Progress to next tier</span>
+              <span className="text-white/80">Progress to next tier</span>
               <span className="font-mono text-white">
                 {totalScore.toFixed(1)} / {data.maxScore} pts
               </span>


### PR DESCRIPTION
## 작업 내용
- 관리자 사용자/포인트 관리 페이지 검색창 안내 문구를 현재 동작에 맞게 `이름으로 검색`으로 수정했습니다.
- 두 페이지 모두 `현재 사용자 검색은 이름 기준으로만 지원합니다.` 안내 문구를 추가했습니다.
- GitHub 랭크 카드의 영어 보조 문구 색상을 흰색 계열로 조정해 가독성을 개선했습니다.
- 프로필 GitHub 카드와 기여 개요의 `Repositories` 표시는 신뢰 가능한 `recent-activity` 개수 기준으로 바꾸고 `Recent Repos`로 정리했습니다.

## 확인 사항
- dev API의 `/v1/users/{userId}/github/overall-history`에서 `contributedRepoCount`가 비정상적으로 큰 값으로 내려와, 이 값을 레포 수로 직접 노출하지 않도록 수정했습니다.

## 검증
- `./node_modules/.bin/eslint src/app/admin/users/list/page.tsx src/app/admin/points/page.tsx src/common/components/GithubRankCard/index.tsx src/app/user/UserPageClient.tsx 'src/app/user/[id]/UserProfileClient.tsx'`
- `./node_modules/.bin/tsc --noEmit`
