### PR TITLE
관리자 검색 플레이스홀더 문구 수정

### DIFF
--- a/src/app/admin/points/page.tsx
+++ b/src/app/admin/points/page.tsx
@@ -281,7 +281,7 @@ export default function AdminPointsPage() {
                 <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
                 <input
                   type="text"
-                  placeholder="이름으로 검색"
+                  placeholder="이름, 학번, 이메일로 검색"
                   value={searchQuery}
                   onChange={(e) => handleSearchChange(e.target.value)}
                   className="w-full rounded-lg border border-gray-200 bg-white py-2.5 pl-9 pr-9 text-sm transition-colors focus:border-gray-400 focus:outline-none"
@@ -315,9 +315,6 @@ export default function AdminPointsPage() {
               />
               탈퇴 회원 제외
             </label>
-            <p className="text-xs text-gray-500">
-              현재 사용자 검색은 이름 기준으로만 지원합니다.
-            </p>
           </div>
         </div>
 

--- a/src/app/admin/users/list/page.tsx
+++ b/src/app/admin/users/list/page.tsx
@@ -373,7 +373,7 @@ export default function AdminUsersPage() {
                 <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
                 <input
                   type="text"
-                  placeholder="이름으로 검색"
+                  placeholder="이름, 학번, 이메일로 검색"
                   value={searchQuery}
                   onChange={(e) => handleSearchChange(e.target.value)}
                   className="w-full rounded-lg border border-gray-200 bg-white py-2.5 pl-9 pr-9 text-sm transition-colors focus:border-gray-400 focus:outline-none"
@@ -407,9 +407,6 @@ export default function AdminUsersPage() {
               />
               탈퇴 회원 제외
             </label>
-            <p className="text-xs text-gray-500">
-              현재 사용자 검색은 이름 기준으로만 지원합니다.
-            </p>
           </div>
         </div>
 


### PR DESCRIPTION
## 작업 내용
- 관리자 사용자 관리 페이지 검색창 placeholder를 `이름, 학번, 이메일로 검색`으로 수정했습니다.
- 관리자 포인트 관리 페이지 검색창 placeholder도 동일하게 맞췄습니다.
- 이전에 추가했던 이름 전용 안내 문구는 실제 동작과 달라 제거했습니다.

## 검증
- `./node_modules/.bin/eslint src/app/admin/users/list/page.tsx src/app/admin/points/page.tsx`
- `./node_modules/.bin/tsc --noEmit`
