### PR TITLE
관리자 검색 플레이스홀더 문구 수정

### DIFF
--- a/src/app/admin/points/page.tsx
+++ b/src/app/admin/points/page.tsx
@@ -281,7 +281,7 @@ export default function AdminPointsPage() {
                 <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
                 <input
                   type="text"
-                  placeholder="이름으로 검색"
+                  placeholder="이름, 학번, 이메일로 검색"
                   value={searchQuery}
                   onChange={(e) => handleSearchChange(e.target.value)}
                   className="w-full rounded-lg border border-gray-200 bg-white py-2.5 pl-9 pr-9 text-sm transition-colors focus:border-gray-400 focus:outline-none"
@@ -315,9 +315,6 @@ export default function AdminPointsPage() {
               />
               탈퇴 회원 제외
             </label>
-            <p className="text-xs text-gray-500">
-              현재 사용자 검색은 이름 기준으로만 지원합니다.
-            </p>
           </div>
         </div>
 

--- a/src/app/admin/users/list/page.tsx
+++ b/src/app/admin/users/list/page.tsx
@@ -373,7 +373,7 @@ export default function AdminUsersPage() {
                 <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
                 <input
                   type="text"
-                  placeholder="이름으로 검색"
+                  placeholder="이름, 학번, 이메일로 검색"
                   value={searchQuery}
                   onChange={(e) => handleSearchChange(e.target.value)}
                   className="w-full rounded-lg border border-gray-200 bg-white py-2.5 pl-9 pr-9 text-sm transition-colors focus:border-gray-400 focus:outline-none"
@@ -407,9 +407,6 @@ export default function AdminUsersPage() {
               />
               탈퇴 회원 제외
             </label>
-            <p className="text-xs text-gray-500">
-              현재 사용자 검색은 이름 기준으로만 지원합니다.
-            </p>
           </div>
         </div>
 


### PR DESCRIPTION
## ✨ 요약

```ts
1. 관리자 사용자 관리 검색창 문구 수정
   - 사용자 관리 페이지의 검색창 placeholder를 `이름, 학번, 이메일로 검색`으로 변경했습니다.
   - 실제 동작이 이름, 학번/사번, 이메일 매칭을 모두 지원하는 현재 구현과 안내 문구를 일치시켰습니다.

2. 관리자 포인트 관리 검색창 문구 수정
   - 포인트 관리 페이지의 검색창 placeholder도 동일하게 `이름, 학번, 이메일로 검색`으로 변경했습니다.
   - 사용자 관리 페이지와 같은 검색 경험을 제공하도록 문구를 통일했습니다.

3. 잘못된 보조 안내 제거
   - 이전에 임시로 추가했던 이름 전용 안내 문구는 실제 검색 동작과 달라 혼선을 줄 수 있어 제거했습니다.
   - 이제 입력창 문구만으로도 현재 검색 기준을 정확히 안내합니다.
```

<br><br>

## 😎 해결한 이슈

- 없음

<br><br>

## 📚 문서 동기화

- [x] 문서 영향 없음
- [ ] Wiki 반영 완료
- [ ] `docs/` 반영 완료
- [x] 반영한 문서 경로: 없음

<br><br>
